### PR TITLE
Use default-directory variable instead of buffer-file-name to pick root

### DIFF
--- a/treemacs.el
+++ b/treemacs.el
@@ -651,14 +651,13 @@ If no treemacs buffer exists call `treemacs-init.'"
 ;;;###autoload
 (defun treemacs-init (&optional arg)
   "Open treemacs with current buffer's directory as root.
-If the current buffer is not visiting any files use $HOME as fallback.
+If the current buffer's default-directory is nil, use $HOME as fallback.
 If a prefix argument ARG is given manually select the root directory."
   (interactive "P")
   (let ((current-file (buffer-file-name (current-buffer))))
     (treemacs--init (cond
                      (arg (read-directory-name "Treemacs root: "))
-                     ((and current-file (f-directory? current-file)) current-file)
-                     (current-file (treemacs--parent current-file))
+                     (default-directory default-directory)
                      (t (getenv "HOME"))))))
 
 ;;;###autoload

--- a/treemacs.el
+++ b/treemacs.el
@@ -654,11 +654,10 @@ If no treemacs buffer exists call `treemacs-init.'"
 If the current buffer's default-directory is nil, use $HOME as fallback.
 If a prefix argument ARG is given manually select the root directory."
   (interactive "P")
-  (let ((current-file (buffer-file-name (current-buffer))))
-    (treemacs--init (cond
-                     (arg (read-directory-name "Treemacs root: "))
-                     (default-directory default-directory)
-                     (t (getenv "HOME"))))))
+  (treemacs--init (cond
+                   (arg (read-directory-name "Treemacs root: "))
+                   (default-directory default-directory)
+                   (t (getenv "HOME")))))
 
 ;;;###autoload
 (defun treemacs-projectile-init (&optional arg)


### PR DESCRIPTION
Currently, treemacs-init doesn't initialize the root correctly in dired-mode buffers because (buffer-file-name (current-buffer)) is always nil for such buffers. Looking at the buffer's default-directory is a more reliable way of getting the root. Also, it avoids the need to check if the buffer-file-name is a file or a directory.