### PR TITLE
do not remove slash if path only contains slash

### DIFF
--- a/treemacs.el
+++ b/treemacs.el
@@ -647,7 +647,8 @@ If a prefix argument ARG is given manually select the root directory."
                    (default-directory
                      ;; default direcoty (usually) ends with a slash, while the dir names
                      ;; given by f.el do not
-                     (if (s-ends-with? "/" default-directory)
+                     (if (and (s-ends-with? "/" default-directory)
+                              (> (length default-directory) 1))
                          (substring default-directory 0 -1)
                        default-directory))
                    (t (getenv "HOME")))))


### PR DESCRIPTION
Handle case when treemacs is initialized in root directory