### PR TITLE
Two changes relating to deletion

### DIFF
--- a/treemacs.el
+++ b/treemacs.el
@@ -400,9 +400,10 @@ Also remove any dirs below if PURGE is given."
   (let* ((parent (treemacs--parent path))
          (cache  (assoc parent treemacs--open-dirs-cache))
          (values (cdr cache)))
-    (if (= 1 (seq-length values))
-        (setq treemacs--open-dirs-cache (delete cache treemacs--open-dirs-cache))
-      (setcdr cache (delete path values)))
+    (when values
+      (if (= 1 (seq-length values))
+          (setq treemacs--open-dirs-cache (delete cache treemacs--open-dirs-cache))
+        (setcdr cache (delete path values))))
     (when purge
       (-if-let (children (-flatten (--map (cdr (assoc it treemacs--open-dirs-cache)) values)))
           (progn

--- a/treemacs.el
+++ b/treemacs.el
@@ -855,6 +855,7 @@ Do nothing for directories."
                 (f-delete path t)
                 (treemacs--clear-from-cache path t)
                 t))))
+        (dired-clean-up-after-deletion path)
         (progn (treemacs--without-messages (treemacs-refresh))
                (goto-char pos))))
   (treemacs-goto-column-1))


### PR DESCRIPTION
Fixed a bug with treemacs--clear-from-cache. Basically, it's possible when you delete a folder that it isn't   in the cache at all but this still calls the clear-from-cache function. And (= 1 nil) results in an error.

Also, added prompts to kill opened buffers after deleting a file/folder.