### PR TITLE
Fix selected-icon-background to work with default Emacs theme

### DIFF
--- a/treemacs-visuals.el
+++ b/treemacs-visuals.el
@@ -48,11 +48,11 @@ after a theme change.")
   "The last button treemacs has highlighted.")
 
 (defvar treemacs--selected-icon-background
-  (face-attribute 'hl-line :background)
+  (face-attribute 'hl-line :background nil t)
   "Background for selected icons.")
 
 (defvar treemacs--not-selected-icon-background
-  (face-attribute 'default :background)
+  (face-attribute 'default :background nil t)
   "Background for non-selected icons.")
 
 (defsubst treemacs--set-img-property (image property value)
@@ -82,11 +82,8 @@ after a theme change.")
 Fetch the current theme's background & hl-line colors and inject them into
 `treemacs--icons'. Also called as advice after `load-theme', hence the ignored
 argument."
-  (setq treemacs--not-selected-icon-background (face-attribute 'default :background)
-        treemacs--selected-icon-background     (face-attribute 'hl-line :background))
-  ;; adwaita workaround
-  (when (equal treemacs--selected-icon-background 'unspecified)
-    (setq treemacs--selected-icon-background (face-attribute 'highlight :background)))
+  (setq treemacs--not-selected-icon-background (face-attribute 'default :background nil t)
+        treemacs--selected-icon-background     (face-attribute 'hl-line :background nil t))
   (--each treemacs--icons
     (progn
       (treemacs--set-img-property


### PR DESCRIPTION
I had a problem with the icon of the selected file disappearing.

Before:
<img width="1729" alt="screen shot 2017-09-15 at 3 40 09 pm" src="https://user-images.githubusercontent.com/3003281/30500422-359ce214-9a2c-11e7-9b2a-c66e55d438d7.png">

After:
<img width="1729" alt="screen shot 2017-09-15 at 3 32 44 pm" src="https://user-images.githubusercontent.com/3003281/30500168-30d9ea5c-9a2b-11e7-87ef-5e78b990955b.png">