### PR TITLE
Fix incorrect icon background colors after enabling/disabling theme

### DIFF
--- a/treemacs-visuals.el
+++ b/treemacs-visuals.el
@@ -79,12 +79,14 @@ after a theme change.")
 (defun treemacs--setup-icon-highlight ()
   "Make sure treemacs icons background aligns with hi-line's."
   (advice-add #'hl-line-highlight :after #'treemacs--update-icon-selection)
-  (advice-add #'load-theme        :after #'treemacs--setup-icon-background-colors))
+  (advice-add #'enable-theme        :after #'treemacs--setup-icon-background-colors)
+  (advice-add #'disable-theme        :after #'treemacs--setup-icon-background-colors))
 
 (defun treemacs--tear-down-icon-highlight ()
   "Tear down highlighting advice when no treemacs buffer exists anymore."
   (advice-remove #'hl-line-highlight #'treemacs--update-icon-selection)
-  (advice-remove #'load-theme        #'treemacs--setup-icon-background-colors)
+  (advice-remove #'enable-theme        #'treemacs--setup-icon-background-colors)
+  (advice-remove #'disable-theme        #'treemacs--setup-icon-background-colors)
   (treemacs--forget-last-highlight))
 
 (defun treemacs--setup-icon-background-colors (&rest _)


### PR DESCRIPTION
It's better to defadvice around enable/disable theme rather than load theme. After loading a theme, a user may enable or disable it, and treemacs won't match the new colors. On the other hand, load-theme calls enable theme, so it's not necessary to defadvice load-theme.