### PR TITLE
Fix undefined variable error in popwin advice

### DIFF
--- a/treemacs-compatibility.el
+++ b/treemacs-compatibility.el
@@ -42,8 +42,8 @@
 
   (defadvice popwin:create-popup-window
       (around treemacs--popwin-popup-buffer activate)
-    (let ((v? (treemacs--is-visible?))
-          (tb (get-buffer treemacs--buffer-name)))
+    (let* ((v? (treemacs--is-visible?))
+  	   (tb (and v? (treemacs--get-framelocal-buffer))))
       (when v?
         (with-current-buffer tb
           (setq window-size-fixed nil)))
@@ -54,8 +54,8 @@
 
   (defadvice popwin:close-popup-window
       (around treemacs--popwin-close-buffer activate)
-    (let ((v? (treemacs--is-visible?))
-          (tb (get-buffer treemacs--buffer-name)))
+    (let* ((v? (treemacs--is-visible?))
+	   (tb (and v? (treemacs--get-framelocal-buffer))))
       (when v?
         (with-current-buffer tb
           (setq window-size-fixed nil)))

--- a/treemacs-compatibility.el
+++ b/treemacs-compatibility.el
@@ -38,32 +38,6 @@
   (when (boundp 'winum-assign-functions)
     (add-to-list 'winum-assign-functions #'treemacs--window-number-ten)))
 
-(with-eval-after-load 'popwin
-
-  (defadvice popwin:create-popup-window
-      (around treemacs--popwin-popup-buffer activate)
-    (let* ((v? (treemacs--is-visible?))
-  	   (tb (and v? (treemacs--get-framelocal-buffer))))
-      (when v?
-        (with-current-buffer tb
-          (setq window-size-fixed nil)))
-      ad-do-it
-      (when v?
-        (with-current-buffer tb
-          (setq window-size-fixed 'width)))))
-
-  (defadvice popwin:close-popup-window
-      (around treemacs--popwin-close-buffer activate)
-    (let* ((v? (treemacs--is-visible?))
-	   (tb (and v? (treemacs--get-framelocal-buffer))))
-      (when v?
-        (with-current-buffer tb
-          (setq window-size-fixed nil)))
-      ad-do-it
-      (when v?
-        (with-current-buffer tb
-          (setq window-size-fixed 'width))))))
-
 (with-eval-after-load 'golden-ratio
   (when (bound-and-true-p golden-ratio-exclude-modes)
     (add-to-list 'golden-ratio-exclude-modes 'treemacs-mode)))


### PR DESCRIPTION
Commit 3984a01c8b54509b6 didn't replace usage of removed variable
`treemacs--buffer-name`in advice to function
`popwin:{create,close}-popup-window` with
`treemacs--get-framelocal-buffer`.