### PR TITLE
Use unicode bullet instead of black slightly small circle

### DIFF
--- a/src/elisp/treemacs-tags.el
+++ b/src/elisp/treemacs-tags.el
@@ -35,7 +35,7 @@
   (require 'treemacs-macros))
 
 (treemacs--defvar-with-default
- treemacs-icon-tag-leaf-text (propertize "🞄 " 'face 'font-lock-constant-face))
+ treemacs-icon-tag-leaf-text (propertize "• " 'face 'font-lock-constant-face))
 (treemacs--defvar-with-default
  treemacs-icon-tag-node-closed-text (propertize "▸ " 'face 'font-lock-string-face))
 (treemacs--defvar-with-default


### PR DESCRIPTION
The `treemacs-icon-tag-leaf-text` now is the unicode black slightly small circle and it's quite rare as a glyph in many fonts. I suggest you switch to using the very similar but far more common unicode bullet instead.