### PR TITLE
Temporarily disable run-mode-hooks during imenu index

### DIFF
--- a/src/elisp/treemacs-tags.el
+++ b/src/elisp/treemacs-tags.el
@@ -139,18 +139,18 @@ should be placed under."
         (existing-buffer (get-file-buffer file)))
     (if existing-buffer
         (setq buff existing-buffer)
-      (setq buff (find-file-noselect file)))
-    (with-current-buffer buff
-      (setq result (condition-case _
-                       (imenu--make-index-alist t)
-                     (error nil))
-            mode major-mode))
-    (unless existing-buffer (kill-buffer buff))
-    (when result
-      (when (string= "*Rescan*" (car (car result)))
-        (setq result (cdr result)))
-      (unless (equal result '(nil))
-        (treemacs--post-process-index result mode)))))
+      (letf (((symbol-function 'run-mode-hooks) (symbol-function 'ignore)))
+        (setq buff (find-file-noselect file))))
+    (when (buffer-live-p buff)
+      (with-current-buffer buff
+        (setq result (imenu--make-index-alist t)
+              mode major-mode))
+      (unless existing-buffer (kill-buffer buff))
+      (when result
+        (when (string= "*Rescan*" (car (car result)))
+          (setq result (cdr result)))
+        (unless (equal result '(nil))
+          (treemacs--post-process-index result mode))))))
 
 (defun treemacs--add-to-tags-cache (btn)
   "Add BTN's path to the cache of open nodes."


### PR DESCRIPTION
People set all kinds of mode hooks to the major modes. For modes such as js-mode or python-mode, there are a lot of linters or code analyzers that call out to external processes. The problem currently with treemacs's way to get tags for a file is that it uses a real buffer complete with it's major mode, and as soon as it has gathered all the tags from the imenu index, the buffer is killed immediately, while the launched processes are still running. When the processes return a result, the buffer would have been killed and a `Selecting deleted buffer` error will result, and stops the rest of the get tags business. This PR fixes this bug. This PR also makes getting the tags slightly faster as well.