### PR TITLE
An option to customize the icon size.

### DIFF
--- a/README.org
+++ b/README.org
@@ -287,6 +287,10 @@ You can find an exhaustive overview of all functions, their keybinds and functio
             treemacs-tag-follow-delay           1.5
             treemacs-width                      35)
 
+      ;; The default width and height of the icons is 22 pixels. If you are
+      ;; using a Hi-DPI display, uncomment this to double the icon size.
+      ;;(treemacs-resize-icons 44)
+
       (treemacs-follow-mode t)
       (treemacs-filewatch-mode t)
       (pcase (cons (not (null (executable-find "git")))


### PR DESCRIPTION
The icons aren't quite the right size for me.

I mainly work with two environments, in one of them I use a 200 DPI monitor and therefore I need the icons to be double the size to match the size of the text.

The other environment I work with has a 96 DPI monitor but I use a small font, which means I actually need the icons to shrink a little to match the size of the text.

This variable allows me to right-size the icons to accomodate both.