### PR TITLE
[FIX] treemacs-select-window init treemacs buffer

### DIFF
--- a/src/elisp/treemacs.el
+++ b/src/elisp/treemacs.el
@@ -170,9 +170,11 @@ visiting a file or Emacs cannot find any tags for the current file."
 Call `treemacs' if it is not."
   (interactive)
   (force-mode-line-update)
-  (--if-let (treemacs--is-visible?)
-      (treemacs--select-visible-window)
-    (treemacs--select-not-visible-window)))
+  (-pcase (treemacs--current-visibility)
+    [`visible (treemacs--select-visible-window)]
+    [`exists (treemacs--select-not-visible-window)]
+    [`none (treemacs--init)])
+)
 
 (provide 'treemacs)
 


### PR DESCRIPTION
If treemacs buffer was not initialized beforehand - treemacs-select-window will be broken. As it is bound to `M-m 0` it could be used as general *select or open treemacs* key.
So it should check if it exists and init it, if its not