### PR TITLE
Fix hardcoded treemacs--persist-file

### DIFF
--- a/README.org
+++ b/README.org
@@ -209,8 +209,8 @@ Treemacs' sessions - your workspace and the projects it contains - are saved whe
 treemacs is first loaded. This persistence process is fully automatic and independant, and should therefore be fully
 compatible with ~desktop-save-mode~.
 
-The persisted state is saved under ~user-emacs-directory/.cache/treemacs-persist~. The exact file location
-is saved in the variable ~treemacs--persist-file~.
+The persisted state is saved under ~user-emacs-directory/.cache/treemacs-persist~ by default. The exact file location
+is saved in the variable ~treemacs-persist-file~.
 
 ** Terminal Compatibility
 When run in a terminal treemacs will fall back to a much simpler rendering system, foregoing its usual png icons and
@@ -275,6 +275,7 @@ You can find an exhaustive overview of all functions, their keybinds and functio
             treemacs-is-never-other-window      nil
             treemacs-no-png-images              nil
             treemacs-project-follow-cleanup     nil
+            treemacs-persist-file               (expand-file-name ".cache/treemacs-persist" user-emacs-directory)
             treemacs-recenter-after-file-follow nil
             treemacs-recenter-after-tag-follow  nil
             treemacs-show-hidden-files          t
@@ -345,6 +346,7 @@ Treemacs offers the following configuration options (~describe-variable~ will us
 | treemacs-pulse-on-success           | t                                           | When non-nil treemacs will pulse the current line as a success indicator, e.g. when creating a file.                                                                                       |
 | treemacs-pulse-on-failure           | t                                           | When non-nil treemacs will pulse the current line as a failure indicator, e.g. when failing to find a file's tags.                                                                         |
 | treemacs-elisp-imenu-expression     | [too large to list]                         | The imenu expression treemacs uses in elisp buffers.                                                                                                                                       |
+| treemacs-persist-file               | "~/.emacs.d/.cache/treemacs-persist"        | Path to the file treemacs uses to persist its state.                                                                                                                                       |
 
 ** Faces
 Treemacs defines and uses the following faces:

--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -20,6 +20,8 @@
 
 ;;; Code:
 
+(require 'f)
+
 ;; defined here since, with the exception of the main file that cannot be required
 ;; elsewhere, this is the first unit to be loaded
 (defconst treemacs--image-creation-impossible
@@ -474,6 +476,12 @@ is expanded while all others will remain collapsed.
 Setting this to t might lead to noticeable slowdowns, at least when `treemacs-git-mode'
 is enabled, since constantly expanding an entire project is farily expensive."
   :type 'boolean
+  :group 'treemacs-configuration)
+
+(defcustom treemacs-persist-file
+  (f-join user-emacs-directory ".cache" "treemacs-persist")
+  "Path to the file treemacs uses to persist its state."
+  :type 'string
   :group 'treemacs-configuration)
 
 (provide 'treemacs-customization)

--- a/src/elisp/treemacs-persistence.el
+++ b/src/elisp/treemacs-persistence.el
@@ -22,29 +22,27 @@
 
 (require 'f)
 (require 'treemacs-workspaces)
-
-(defconst treemacs--persist-file (f-join user-emacs-directory ".cache" "treemacs-persist")
-  "File treemacs uses to persist its state.")
+(require 'treemacs-customization)
 
 (defun treemacs--persist ()
-  "Persist treemacs' state in `treemacs--persist-file'."
+  "Persist treemacs' state in `treemacs-persist-file'."
   (unless noninteractive
-    (unless (f-exists? treemacs--persist-file)
-      (f-mkdir user-emacs-directory ".cache")
-      (f-touch treemacs--persist-file))
+    (unless (f-exists? treemacs-persist-file)
+      (f-mkdir (f-dirname treemacs-persist-file))
+      (f-touch treemacs-persist-file))
     (condition-case e
         (-> treemacs-current-workspace
             (list)
             (pp-to-string)
-            (f-write 'utf-8 treemacs--persist-file))
+            (f-write 'utf-8 treemacs-persist-file))
       (error (treemacs-log "Error '%s' when persisting workspace." e)))))
 
 (defun treemacs--restore ()
-  "Restore treemacs' state from `treemacs--persist-file'."
+  "Restore treemacs' state from `treemacs-persist-file'."
   (unless noninteractive
     (condition-case e
-        (when (f-exists? treemacs--persist-file)
-          (-when-let- [workspace (-> treemacs--persist-file (f-read 'utf-8) (read) (car))]
+        (when (f-exists? treemacs-persist-file)
+          (-when-let- [workspace (-> treemacs-persist-file (f-read 'utf-8) (read) (car))]
             (dolist (project (treemacs-workspace->projects workspace))
               (unless (-> project (treemacs-project->path) (f-exists?))
                 (treemacs-log (format "Project at %s does not exist and was removed from the workspace."


### PR DESCRIPTION
For those of us that'd like to centralize cache files and folders, this change:

1. Renames `treemacs--persist-file` to `treemacs-persist-file` (to imply that it is now public and safe to modify), 
2. Defines it with `defvar` so that, if a value has already been assigned to the variable, it won't be changed. `defconst` disregards customizations and resets its value much like `setq` does. 
3. Removes the hardcoded creation of the `~/.emacs.d/.cache` directory (`(f-mkdir user-emacs-directory ".cache")`.
4. Updates the reference to `treemacs-persist-file` in the README.

This makes it possible to truly customize where treemacs saves its persistence file.

EDIT: Or should I have used `defcustom`?