### PR TITLE
Preserve original file name when renaming it

### DIFF
--- a/src/elisp/treemacs-interface.el
+++ b/src/elisp/treemacs-interface.el
@@ -361,7 +361,7 @@ likewise be updated."
         (unless (file-exists-p old-path)
           (cl-return-from body
            (treemacs-pulse-on-failure "The file to be renamed does not exist.")))
-        (setq new-name (read-string "New name: ")
+        (setq new-name (read-string "New name: " (file-name-nondirectory old-path))
               dir      (f-dirname old-path)
               new-path (f-join dir new-name))
         (when (file-exists-p new-path)


### PR DESCRIPTION
IMO, most of the times it's better to have the original name as a default rename target, i.e. you'd like to only change a file extension or fix a tiny typo in a filename :slightly_smiling_face: 
`C-w` should do the trick if you don't like the original name one bit anyways