### PR TITLE
Add support for doom-modeline

### DIFF
--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -260,6 +260,9 @@ to it will instead show a blank."
               ((memq 'moody-mode-line-buffer-identification
                      (default-value 'mode-line-format))
                '(:eval (moody-tab " Treemacs " 10 'down)))
+              ((fboundp 'doom-modeline-def-modeline)
+               (doom-modeline-def-modeline 'treemacs '(bar " " major-mode))
+               (doom-modeline 'treemacs))
               (t
                '(" Treemacs ")))))
 


### PR DESCRIPTION
Add support for [doom-modeline](https://github.com/seagle0128/doom-modeline)

before
![](https://user-images.githubusercontent.com/13600799/51016928-1ce7f580-15ad-11e9-8d5d-25cd5487baa2.png)

after
![](https://user-images.githubusercontent.com/13600799/51016940-296c4e00-15ad-11e9-9154-2dc8ca5cc3f3.png)
