### PR TITLE
[Keybinds] Introduce keymaps for commands that share a common prefix

### DIFF
--- a/src/extra/treemacs-projectile.el
+++ b/src/extra/treemacs-projectile.el
@@ -56,7 +56,7 @@ the project's root directory."
                  (propertize (treemacs-project->name duplicate) 'face 'font-lock-type-face)))))))
     (treemacs-pulse-on-failure "It looks like projectile does not know any projects.")))
 
-(define-key treemacs-mode-map (kbd "C-p p") #'treemacs-projectile)
+(define-key treemacs-project-map (kbd "p") #'treemacs-projectile)
 
 (defun treemacs--read-first-project-path ()
   "Overwrites the original definition from `treemacs-impl'.


### PR DESCRIPTION
- This makes it easy to adjust keybindings for commands in one place, even
  when they are defined in different source files.

- This change also makes it easier for users to adjust keybindings, as
  discussed in bug #337.

- Probably `treemacs-evil.el` could be modified accordingly as well; I have
  not investigated this further.

- This patch does not change any keybindings