### PR TITLE
[Persistence] Handling of missing persisted projects

### DIFF
--- a/README.org
+++ b/README.org
@@ -340,6 +340,7 @@ setting. Setting them all yourself is not necessary, they are only listed here t
             treemacs-indentation-string            " "
             treemacs-is-never-other-window         nil
             treemacs-max-git-entries               5000
+            treemacs-missing-project-action        'ask
             treemacs-no-png-images                 nil
             treemacs-no-delete-other-windows       t
             treemacs-project-follow-cleanup        nil
@@ -442,6 +443,7 @@ Treemacs offers the following configuration options (~describe-variable~ will us
 | treemacs-file-follow-delay             | 0.2                                         | Delay in seconds of idle time for treemacs to follow the selected window.                                                                                                                  |
 | treemacs-display-in-side-window        | t                                           | When non-nil treemacs will use a dedicated [[https://www.gnu.org/software/emacs/draft/manual/html_node/elisp/Side-Windows.html][side-window]].                                                                                                                                    |
 | treemacs-max-git-entries               | 5000                                        | Maximum number of git status entries treemacs will process. Anything above that number will be ignored.                                                                                    |
+| treemacs-missing-project-action        | ask                                         | When a persisted project is missing from filesystem, ~ask~ will prompt for action, ~keep~ will keep the project in the project list, and ~remove~ will remove it from it without prompt.   |
 | treemacs-show-cursor                   | nil                                         | When non-nil the cursor will stay visible in the treemacs buffer.                                                                                                                          |
 | treemacs-git-command-pipe              | ""                                          | Text to be appended to treemacs' git command. Useful for filtering with something like grep.                                                                                               |
 | treemacs-no-delete-other-windows       | t                                           | Prevents the treemacs window from being deleted by commands like ~delete-other-windows~ and ~magit-status~.                                                                                |

--- a/README.org
+++ b/README.org
@@ -451,19 +451,23 @@ Treemacs offers the following configuration options (~describe-variable~ will us
 
 ** Faces
 Treemacs defines and uses the following faces:
-| Face                              | Based on                     | Description                                                                  |
-|-----------------------------------+------------------------------+------------------------------------------------------------------------------|
-| treemacs-directory-face           | font-lock-function-name-face | Face used for directories.                                                   |
-| treemacs-directory-collapsed-face | treemacs-directory-face      | Face used for collapsed part of directories.                                 |
-| treemacs-file-face                | default                      | Face used for files.                                                         |
-| treemacs-root-face                | font-lock-constant-face      | Face used for project roots.                                                 |
-| treemacs-tags-face                | font-lock-builtin-face       | Face used for tags.                                                          |
-| treemacs-help-title-face          | font-lock-constant-face      | Face used for the title of the helpful hydra.                                |
-| treemacs-help-column-face         | font-lock-keyword-face       | Face used for the column headers of the helpful hydra.                       |
-| treemacs-git-*-face               | various font lock faces      | Faces used by treemacs for various git states.                               |
-| treemacs-term-node-face           | font-lock-string-face        | Face for directory node symbols used by treemacs when it runs in a terminal. |
-| treemacs-on-success-pulse-face    | :fg #111111 :bg #669966      | Pulse face used when pulsing on a successful action.                         |
-| treemacs-on-failure-puse-face     | :fg #111111 :bg #ab3737      | Pulse face used when pulsing on a failed action.                             |
+| Face                                   | Based on                                         | Description                                                                  |
+|----------------------------------------+--------------------------------------------------+------------------------------------------------------------------------------|
+| treemacs-directory-face                | font-lock-function-name-face                     | Face used for directories.                                                   |
+| treemacs-directory-collapsed-face      | treemacs-directory-face                          | Face used for collapsed part of directories.                                 |
+| treemacs-file-face                     | default                                          | Face used for files.                                                         |
+| treemacs-root-face                     | font-lock-constant-face                          | Face used for project roots.                                                 |
+| treemacs-root-unreadable-face          | treemacs-root-face                               | Face used for local unreadable project roots.                                |
+| treemacs-root-remote-face              | font-lock-function-name-face, treemacs-root-face | Face used for readable remote (Tramp) project roots.                         |
+| treemacs-root-remote-unreadable-face   | treemacs-root-unreadable-face                    | Face used for unreadable remote (Tramp) project roots.                       |
+| treemacs-root-remote-disconnected-face | warning, treemacs-root-face                      | Face used for disconnected remote (Tramp) project roots.                     |
+| treemacs-tags-face                     | font-lock-builtin-face                           | Face used for tags.                                                          |
+| treemacs-help-title-face               | font-lock-constant-face                          | Face used for the title of the helpful hydra.                                |
+| treemacs-help-column-face              | font-lock-keyword-face                           | Face used for the column headers of the helpful hydra.                       |
+| treemacs-git-*-face                    | various font lock faces                          | Faces used by treemacs for various git states.                               |
+| treemacs-term-node-face                | font-lock-string-face                            | Face for directory node symbols used by treemacs when it runs in a terminal. |
+| treemacs-on-success-pulse-face         | :fg #111111 :bg #669966                          | Pulse face used when pulsing on a successful action.                         |
+| treemacs-on-failure-puse-face          | :fg #111111 :bg #ab3737                          | Pulse face used when pulsing on a failed action.                             |
 
 ** Evil compatibility
 To make treemacs get along with evil-mode you need to install and load ~treemacs-evil~. It does not define any functions

--- a/src/elisp/treemacs-async.el
+++ b/src/elisp/treemacs-async.el
@@ -293,8 +293,10 @@ FILE: Filepath"
                          file (treemacs--remove-trailing-newline status))
            (treemacs-log "\"%s\"" (treemacs--remove-trailing-newline err-str))))))))
 
-(defun treemacs--collapsed-dirs-process (path)
+(defun treemacs--collapsed-dirs-process (path project)
   "Start a new process to determine dirs to collpase under PATH.
+Only starts the process if PROJECT is locally accessible (i.e. exists, and
+is not remote.)
 Output format is an elisp list of string lists that's read directly.
 Every string list consists of the following elements:
  * The path that is being collapsed
@@ -302,7 +304,8 @@ Every string list consists of the following elements:
  * The single directories being collapsed, to be put under filewatch
    if `treemacs-filewatch-mode' is on."
   (when (and (> treemacs-collapse-dirs 0)
-             treemacs-python-executable)
+             treemacs-python-executable
+             (treemacs-project->is-local-and-readable? project))
     ;; needs to be set or we'll run into trouble when deleting
     ;; haven't taken the time to figure out why, so let's just leave it at that
     (-let [default-directory path]

--- a/src/elisp/treemacs-async.el
+++ b/src/elisp/treemacs-async.el
@@ -26,6 +26,7 @@
 (require 'pfuture)
 (require 'treemacs-core-utils)
 (require 'treemacs-customization)
+(require 'treemacs-workspaces)
 (require 'treemacs-dom)
 (eval-and-compile
   (require 'inline)
@@ -109,6 +110,12 @@ Specifically its size will be reduced to half of `treemacs--git-cache-max-size'.
   "Dummy with PATH.
 Real implementation will be `fset' based on `treemacs-git-mode' value."
   (ignore path))
+
+(defun treemacs--git-status-process (path project)
+  "Run `treemacs--git-status-process-function' on PATH, if allowed for PROJECT.
+Remote projects are ignored."
+  (when (treemacs-project->is-local-and-readable? project)
+    (treemacs--git-status-process-function path)))
 
 (defun treemacs--git-status-parse-function (_future)
   "Dummy with FUTURE.

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -812,7 +812,7 @@ failed.  PROJECT is used for determining whether Git actions are appropriate."
        `(defun ,name (path)
           ,doc
           (let* (;; go back here if the search fails
-                 (project (pop path))
+                 (project ,project-form)
                  (start (prog1 (point) (goto-char (treemacs-project->position project))))
                  ;; making a copy since the variable is a reference to a node actual path
                  ;; and will be changed in-place here

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -60,7 +60,6 @@
   treemacs--render-projects)
 
 (treemacs-import-functions-from "treemacs-filewatch-mode"
-  treemacs--start-watching
   treemacs--stop-filewatch-for-current-buffer
   treemacs--stop-watching
   treemacs--cancel-refresh-timer)
@@ -91,7 +90,6 @@
   treemacs--invalidate-position-cache)
 
 (treemacs-import-functions-from "treemacs-workspaces"
-  make-treemacs-project
   treemacs--find-workspace
   treemacs-current-workspace
   treemacs-workspace->projects

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -635,15 +635,15 @@ GIT-INFO: Pfuture|HashMap<String, String>"
        (treemacs-on-collapse it :purge)))))
 
 (defun treemacs--nearest-path (btn)
-  "Return the path property of the current button (or BTN).
-If the property is not set keep looking upward, via the :parent' property.
-Useful to e.g. find the path of the file of the currently selected tags entry.
-Must be called from treemacs buffer."
-  (let* ((path (treemacs-button-get btn :path)))
-    (while (null path)
-      (setq btn (treemacs-button-get btn :parent)
-            path (treemacs-button-get btn :path)))
-    path))
+  "Return the file path of the BTN.
+If the `:path' property is not set or not a file, keep looking upward, via the
+`:parent' property.  Useful to e.g. find the path of the file of the currently
+selected tags or extension entry.  Must be called from treemacs buffer."
+  (let ((path (treemacs-button-get btn :path)))
+    (if (stringp path)
+        path
+      (-some-> (treemacs-button-get btn :parent)
+               (treemacs--nearest-path)))))
 
 (defun treemacs--create-file/dir (is-file?)
   "Interactively create either a file or directory, depending on IS-FILE.

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -74,7 +74,7 @@
   treemacs--forget-last-highlight)
 
 (treemacs-import-functions-from "treemacs-async"
-  treemacs--git-status-process-function
+  treemacs--git-status-process
   treemacs--collapsed-dirs-process)
 
 (treemacs-import-functions-from "treemacs-dom"
@@ -699,14 +699,14 @@ failed."
              (funcall (cdr (assq (treemacs-button-get ,btn :state) treemacs-TAB-actions-config))))))
        ,btn))))
 
-(define-inline treemacs--follow-each-dir (btn dir-parts)
+(define-inline treemacs--follow-each-dir (btn dir-parts project)
   "Starting at BTN follow (goto and open) every single dir in DIR-PARTS.
 Return the button that is found or the symbol `follow-failed' if the search
-failed."
-  (inline-letevals (btn dir-parts)
+failed.  PROJECT is used for determining whether Git actions are appropriate."
+  (inline-letevals (btn dir-parts project)
     (inline-quote
      (let* ((root       (treemacs-button-get ,btn :path))
-            (git-future (treemacs--git-status-process-function root))
+            (git-future (treemacs--git-status-process root ,project))
             (last-index (- (length ,dir-parts) 1))
             (depth      (treemacs-button-get ,btn :depth)))
        (goto-char ,btn)
@@ -968,7 +968,7 @@ PROJECT: Project Struct"
                     (treemacs-project->position project)
                   (treemacs-dom-node->position dom-node)))
            ;; do the rest manually - at least the actual file to move to is still left in manual-parts
-           (search-result (if manual-parts (save-match-data (treemacs--follow-each-dir btn manual-parts)) btn)))
+           (search-result (if manual-parts (save-match-data (treemacs--follow-each-dir btn manual-parts project)) btn)))
       (if (eq 'follow-failed search-result)
           (prog1 nil
             (goto-char start))

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -325,13 +325,11 @@ Returns nil if no such buffer exists.."
 (defun treemacs-project-of-node (node)
   "Find the project the given NODE belongs to."
   (declare (side-effect-free t))
-  (if (treemacs-button-get node :custom)
-      (-> node (treemacs-button-get :path) (car))
-    (-let [project (treemacs-button-get node :project)]
-      (while (not project)
-        (setq node (treemacs-button-get node :parent)
-              project (treemacs-button-get node :project)))
-      project)))
+  (-let [project (treemacs-button-get node :project)]
+    (while (not project)
+      (setq node (treemacs-button-get node :parent)
+            project (treemacs-button-get node :project)))
+    project))
 
 (define-inline treemacs--prop-at-point (prop)
   "Grab property PROP of the button at point.

--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -497,6 +497,16 @@ is enabled, since constantly expanding an entire project is fairly expensive."
   :group 'treemacs
   :type 'string)
 
+(defcustom treemacs-missing-project-action 'ask
+  "Action to perform when a persisted project is not found on the disk.
+If the project is not found, the project can either be kept in the project list,
+or removed from it.  If the project is removed, when projects are persisted, the
+missing project will not appear in the project list next time Emacs is started."
+  :type '(choice (const :tag "Ask whether to remove" ask)
+                 (const :tag "Remove without asking" remove)
+                 (const :tag "Keep without asking" keep))
+  :group 'treemacs)
+
 (defcustom treemacs-space-between-root-nodes t
   "When non-nil treemacs will separate root nodes with an empty line."
   :type 'boolean

--- a/src/elisp/treemacs-extensions.el
+++ b/src/elisp/treemacs-extensions.el
@@ -438,7 +438,8 @@ additional keys."
                                    (extension-key (cdr it))
                                    (pr (make-treemacs-project
                                         :name extension-label
-                                        :path extension-key)))
+                                        :path extension-key
+                                        :path-status 'extension)))
                               (insert ,closed-icon-name)
                               (treemacs--set-project-position ,root-key-form (point-marker))
                               (insert (propertize extension-label
@@ -460,7 +461,8 @@ additional keys."
                        (treemacs-with-writable-buffer
                         (-let [pr (make-treemacs-project
                                    :name ,root-label
-                                   :path ,root-key-form)]
+                                   :path ,root-key-form
+                                   :path-status 'extension)]
                           (insert ,closed-icon-name)
                           (treemacs--set-project-position ,root-key-form (point-marker))
                           (setq-local ,project-var-name pr)

--- a/src/elisp/treemacs-faces.el
+++ b/src/elisp/treemacs-faces.el
@@ -42,6 +42,26 @@ if the node is 'foo/bar/baz', the face is used for 'foo/bar/'."
   "Face used by treemacs for its root nodes."
   :group 'treemacs-faces)
 
+(defface treemacs-root-unreadable-face
+  '((t :inherit treemacs-root-face :strike-through t))
+  "Face used by treemacs for unreadable root nodes."
+  :group 'treemacs-faces)
+
+(defface treemacs-root-remote-face
+  '((t :inherit (font-lock-function-name-face treemacs-root-face)))
+  "Face used by treemacs for remote (Tramp) root nodes."
+  :group 'treemacs-faces)
+
+(defface treemacs-root-remote-unreadable-face
+  '((t :inherit treemacs-root-unreadable-face))
+  "Face used by treemacs for unreadable remote (Tramp) root nodes."
+  :group 'treemacs-faces)
+
+(defface treemacs-root-remote-disconnected-face
+  '((t :inherit (warning treemacs-root-remote-face)))
+  "Face used by treemacs for disconnected remote (Tramp) root nodes."
+  :group 'treemacs-faces)
+
 (defface treemacs-term-node-face
   '((t :inherit font-lock-string-face))
   "Face used by treemacs in the terminal for directory node symbols."

--- a/src/elisp/treemacs-filewatch-mode.el
+++ b/src/elisp/treemacs-filewatch-mode.el
@@ -86,11 +86,15 @@ COLLAPSE: Bool"
            ;; just add current buffer to watch list if path is watched already
            (unless (memq (current-buffer) (car watch-info))
              (setcar watch-info (cons (current-buffer) (car watch-info))))
-         ;; make new entry otherwise and set a new watcher
-         (ht-set! treemacs--filewatch-index
-                  ,path
-                  (cons (list (current-buffer))
-                        (file-notify-add-watch ,path '(change) #'treemacs--filewatch-callback))))))))
+         ;; if the Tramp connection does not support watches, don't show an error
+         ;; every time a watch is started.
+         (treemacs-with-ignored-errors
+          ((file-notify-error "No file notification program found"))
+          ;; make new entry otherwise and set a new watcher
+          (ht-set! treemacs--filewatch-index
+                   ,path
+                   (cons (list (current-buffer))
+                         (file-notify-add-watch ,path '(change) #'treemacs--filewatch-callback)))))))))
 
 (define-inline treemacs--stop-watching (path &optional all)
   "Stop watching PATH for file events.

--- a/src/elisp/treemacs-follow-mode.el
+++ b/src/elisp/treemacs-follow-mode.el
@@ -60,10 +60,8 @@ not visible."
                   (f-exists? current-file))
          (-when-let (project-for-file (treemacs--find-project-for-buffer))
            (with-selected-window treemacs-window
-             ;; TODO(2018/10/30): custom file at point?
              (-let [selected-file (--if-let (treemacs-current-button)
-                                      (and (not (treemacs-button-get it :custom))
-                                           (treemacs--nearest-path it))
+                                      (treemacs--nearest-path it)
                                     (treemacs-project->path project-for-file))]
                (unless (treemacs-is-path selected-file :same-as current-file)
                  (when (treemacs-goto-file-node current-file project-for-file)

--- a/src/elisp/treemacs-macros.el
+++ b/src/elisp/treemacs-macros.el
@@ -271,7 +271,10 @@ it on the same line."
       ;; try to stay at the same file/tag
       ;; if the tag no longer exists move to the tag's owning file node
       (pcase curr-state
-        ((or 'root-node-open 'root-node-closed 'dir-node-open 'dir-node-closed 'file-node-open 'file-node-closed)
+        ((or 'root-node-open 'root-node-closed)
+         ;; root nodes are always visible even if deleted.
+         (treemacs-goto-file-node curr-file))
+        ((or 'dir-node-open 'dir-node-closed 'file-node-open 'file-node-closed)
          ;; stay on the same file
          (if (and (file-exists-p curr-file)
                   (or treemacs-show-hidden-files

--- a/src/elisp/treemacs-macros.el
+++ b/src/elisp/treemacs-macros.el
@@ -467,6 +467,22 @@ treemacs buffer exists at all, BODY will be executed."
        (delete-window it)
      ,@body))
 
+(defmacro treemacs-with-ignored-errors (ignored-errors &rest body)
+  "Evaluate BODY with specific errors ignored.
+
+IGNORED-ERRORS is a list of errors to ignore.  Each element is a list whose car
+is the error's type, and second item is a regex to match against error messages.
+If any of the IGNORED-ERRORS matches, the error is suppressed and nil returned."
+  (let ((err (gensym)))
+    `(condition-case-unless-debug ,err
+         ,(macroexp-progn body)
+       ,@(mapcar
+          (lambda (ignore-spec)
+            `(,(car ignore-spec)
+              (unless (string-match-p ,(nth 1 ignore-spec) (error-message-string ,err))
+                (signal (car ,err) (cdr ,err)))))
+          ignored-errors))))
+
 (provide 'treemacs-macros)
 
 ;;; treemacs-macros.el ends here

--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -328,9 +328,10 @@ If there is no node at point use \"~/\" instead.
 
 Used as a post command hook."
   (-if-let* ((btn  (treemacs-current-button))
+             (project (treemacs-project-of-node btn))
              (path (or (treemacs-button-get btn :default-directory)
                        (treemacs--nearest-path btn))))
-      (when (and (stringp path)
+      (when (and (treemacs-project->is-readable? project)
                  (file-readable-p path))
         (setq treemacs--eldoc-msg path
               default-directory (treemacs--add-trailing-slash

--- a/src/elisp/treemacs-persistence.el
+++ b/src/elisp/treemacs-persistence.el
@@ -121,11 +121,32 @@ ITER: Treemacs-Iter struct"
                  (setf (treemacs-project->path project) (treemacs--canonical-path val)))
                 (_
                  (treemacs-log "Encountered unknown project key-value in line [%s]" kv-line)))))
-          (if (-> project (treemacs-project->path) (file-exists-p) (not))
-              (treemacs-log "The location of project %s at %s cannot be read, the project will be ignored."
-                            (propertize (treemacs-project->name project) 'face 'font-lock-type-face)
-                            (propertize (treemacs-project->path project) 'face 'font-lock-string-face))
-            (push project projects)))))
+          (let ((action 'retry))
+            (while (eq action 'retry)
+              (setf (treemacs-project->path-status project)
+                    (-> (treemacs-project->path project)
+                        (treemacs--get-path-status)))
+              (setq action
+                    (cond
+                     ((not (treemacs-project->is-unreadable? project))
+                      'keep)
+                     ((eq treemacs-missing-project-action 'ask)
+                      (let ((completions
+                             '(("Keep the project in the project list" . keep)
+                               ("Retry" . retry)
+                               ("Remove the project from the project list" . remove))))
+                        (cdr (assoc (completing-read
+                                     (format "Project %s at %s cannot be read."
+                                             (treemacs-project->name project)
+                                             (treemacs-project->path project))
+                                     completions nil t)
+                                    completions))))
+                     (treemacs-missing-project-action))))
+            (if (eq action 'remove)
+                (treemacs-log "The location of project %s at %s cannot be read. Project was removed from the project list."
+                              (propertize (treemacs-project->name project) 'face 'font-lock-type-face)
+                              (propertize (treemacs-project->path project) 'face 'font-lock-string-face))
+              (push project projects))))))
     (nreverse projects)))
 
 (defun treemacs--persist ()
@@ -233,28 +254,32 @@ CONTEXT: Keyword"
   "Restore treemacs' state from `treemacs-persist-file'."
   (unless (treemacs--should-not-run-persistence?)
     (-when-let (lines (treemacs--read-persist-lines))
-      (condition-case e
-          (pcase (treemacs--validate-persist-lines lines)
-            ('success
-             (setf treemacs--workspaces (treemacs--read-workspaces (make-treemacs-iter :list lines))
-                   (treemacs-current-workspace) (car treemacs--workspaces)))
-            (`(error ,line ,error-msg)
-             (treemacs--write-error-persist-state lines (format "'%s' in line '%s'" error-msg line))
-             (treemacs-log "Could not restore saved state, %s:\n%s\n%s"
-                           (pcase line
-                             (:start "found error in the first line")
-                             (:end "found error in the last line")
-                             (other (format "found error in line '%s'" other)))
-                           error-msg
+      ;; Don't persist during restore. Otherwise, if the user would quit
+      ;; Emacs during restore, for example during the completing read for
+      ;; missing project action, the whole persist file would be emptied.
+      (let ((kill-emacs-hook (remq #'treemacs--persist kill-emacs-hook)))
+        (condition-case e
+            (pcase (treemacs--validate-persist-lines lines)
+              ('success
+               (setf treemacs--workspaces (treemacs--read-workspaces (make-treemacs-iter :list lines))
+                     (treemacs-current-workspace) (car treemacs--workspaces)))
+              (`(error ,line ,error-msg)
+               (treemacs--write-error-persist-state lines (format "'%s' in line '%s'" error-msg line))
+               (treemacs-log "Could not restore saved state, %s:\n%s\n%s"
+                             (pcase line
+                               (:start "found error in the first line")
+                               (:end "found error in the last line")
+                               (other (format "found error in line '%s'" other)))
+                             error-msg
+                             (format "Broken state was saved to %s"
+                                     (propertize treemacs--last-error-persist-file 'face 'font-lock-string-face)))))
+          (error
+           (progn
+             (treemacs--write-error-persist-state lines e)
+             (treemacs-log "Error '%s' when loading the persisted workspace.\n%s"
+                           e
                            (format "Broken state was saved to %s"
-                                   (propertize treemacs--last-error-persist-file 'face 'font-lock-string-face)))))
-        (error
-         (progn
-           (treemacs--write-error-persist-state lines e)
-           (treemacs-log "Error '%s' when loading the persisted workspace.\n%s"
-                         e
-                         (format "Broken state was saved to %s"
-                                 (propertize treemacs--last-error-persist-file 'face 'font-lock-string-face)))))))))
+                                   (propertize treemacs--last-error-persist-file 'face 'font-lock-string-face))))))))))
 
 (defun treemacs--write-error-persist-state (lines error)
   "Write broken state LINES and ERROR to `treemacs--last-error-persist-file'."

--- a/src/elisp/treemacs-persistence.el
+++ b/src/elisp/treemacs-persistence.el
@@ -232,9 +232,12 @@ CONTEXT: Keyword"
           (treemacs-return-if (not (s-matches? treemacs--persist-kv-regex line))
             `(error ,prev ,(as-warning "Project name must be followed by path declaration")))
           (-let [path (cadr (s-split " :: " line))]
-            ;; path not existing is only a hard error when org-editing, when loading on boot
-            ;; it's just a warning and the project will be ignored
+            ;; Path not existing is only a hard error when org-editing, when loading on boot
+            ;; its significance is determined by the customization setting
+            ;; treemacs-missing-project-action. Remote files are skipped to avoid opening
+            ;; Tramp connections.
             (treemacs-return-if (and (string= treemacs--org-edit-buffer-name (buffer-name))
+                                     (not (file-remote-p path))
                                      (not (file-exists-p path)))
               `(error ,line ,(format (as-warning "File '%s' does not exist") (propertize path 'face 'font-lock-string-face))))
             (treemacs--validate-persist-lines (cdr lines) :property line)))

--- a/src/elisp/treemacs-rendering.el
+++ b/src/elisp/treemacs-rendering.el
@@ -554,7 +554,8 @@ PROJECT: Project Struct"
                'category 'default-button
                'face 'treemacs-root-face
                :project project
-               :symlink (file-symlink-p (treemacs-project->path project))
+               :symlink (when (treemacs-project->is-readable? project)
+                          (file-symlink-p (treemacs-project->path project)))
                :state 'root-node-closed
                :path (treemacs-project->path project)
                :depth 0)))

--- a/src/elisp/treemacs-rendering.el
+++ b/src/elisp/treemacs-rendering.el
@@ -467,7 +467,7 @@ set to PARENT."
   (let* ((path (treemacs-button-get btn :path))
          (project (treemacs-button-get btn :project))
          (git-path (if (treemacs-button-get btn :symlink) (file-truename path) path))
-         (git-future (treemacs--git-status-process-function git-path))
+         (git-future (treemacs--git-status-process git-path project))
          (collapse-future (treemacs--collapsed-dirs-process path)))
     (treemacs--maybe-recenter treemacs-recenter-after-project-expand
       (treemacs--button-open
@@ -504,10 +504,11 @@ RECURSIVE: Bool"
   (if (not (f-readable? (treemacs-button-get btn :path)))
       (treemacs-pulse-on-failure
        "Directory %s is not readable." (propertize (treemacs-button-get btn :path) 'face 'font-lock-string-face))
-    (let* ((path (treemacs-button-get btn :path))
+    (let* ((project (treemacs-project-of-node btn))
+           (path (treemacs-button-get btn :path))
            (git-future (if (treemacs-button-get btn :symlink)
-                           (treemacs--git-status-process-function (file-truename path))
-                         (or git-future (treemacs--git-status-process-function (file-truename path)))))
+                           (treemacs--git-status-process (file-truename path) project)
+                         (or git-future (treemacs--git-status-process path project))))
            (collapse-future (treemacs--collapsed-dirs-process path)))
       (treemacs--button-open
        :immediate-insert nil

--- a/src/elisp/treemacs-rendering.el
+++ b/src/elisp/treemacs-rendering.el
@@ -468,7 +468,7 @@ set to PARENT."
          (project (treemacs-button-get btn :project))
          (git-path (if (treemacs-button-get btn :symlink) (file-truename path) path))
          (git-future (treemacs--git-status-process git-path project))
-         (collapse-future (treemacs--collapsed-dirs-process path)))
+         (collapse-future (treemacs--collapsed-dirs-process path project)))
     (treemacs--maybe-recenter treemacs-recenter-after-project-expand
       (treemacs--button-open
        :immediate-insert nil
@@ -509,7 +509,7 @@ RECURSIVE: Bool"
            (git-future (if (treemacs-button-get btn :symlink)
                            (treemacs--git-status-process (file-truename path) project)
                          (or git-future (treemacs--git-status-process path project))))
-           (collapse-future (treemacs--collapsed-dirs-process path)))
+           (collapse-future (treemacs--collapsed-dirs-process path project)))
       (treemacs--button-open
        :immediate-insert nil
        :button btn

--- a/src/scripts/treemacs-dirs-to-collapse.py
+++ b/src/scripts/treemacs-dirs-to-collapse.py
@@ -8,10 +8,6 @@ ROOT     = sys.argv[1]
 LIMIT    = int(sys.argv[2])
 SHOW_ALL = sys.argv[3] == 't'
 
-if ROOT.startswith("/ssh:") or ROOT.startswith("/scp:"):
-    print("()")
-    sys.exit(0)
-
 # special workaround for windows platforms
 # the default `join' implementation cannot quite deal with windows
 # paths in the form of "C:/A/B" & "C:/A/B/C", joining them as

--- a/test/test-treemacs.el
+++ b/test/test-treemacs.el
@@ -938,6 +938,11 @@
 
     (it "Succeeds on correctly formed input"
       (-let [lines '("* W1" "** P1" " - path :: a" "** P2" "- path :: b" "* W2" "** P3" " - path :: c")]
+        (expect (treemacs--validate-persist-lines lines) :to-be 'success)))
+
+    (it "Succeeds with non-connectable remotes"
+      (let* ((treemacs--org-edit-buffer-name (buffer-name))
+             (lines '("* W1" "** P1" " - path :: /ftp:anonymous@ftp.invalid:/test-path")))
         (expect (treemacs--validate-persist-lines lines) :to-be 'success))))
 
   (describe "Errors"

--- a/test/test-treemacs.el
+++ b/test/test-treemacs.el
@@ -1008,13 +1008,24 @@
       (expect 'treemacs--git-status-process-function
               :to-have-been-called-with path))))
 
+(describe "treemacs--process-collapsed-dirs"
+
+  (it "Does nothing with non-local or unreadable paths"
+    (-let [treemacs-collapse-dirs 3]
+      (dolist (status '(local-unreadable remote-readable remote-unreadable remote-disconnected extension))
+        (expect (-> treemacs-dir
+                    (f-join "test")
+                    (treemacs--collapsed-dirs-process (make-treemacs-project :name "P" :path treemacs-dir :path-status status)))
+                :to-equal
+                nil)))))
+
 (describe "treemacs--parse-collapsed-dirs"
 
   (it "Finds dirs to flatten in test directory"
     (-let [treemacs-collapse-dirs 3]
       (expect (-> treemacs-dir
                   (f-join "test")
-                  (treemacs--collapsed-dirs-process)
+                  (treemacs--collapsed-dirs-process (make-treemacs-project :name "P" :path treemacs-dir :path-status 'local-readable))
                   (treemacs--parse-collapsed-dirs))
               :to-equal
               `((,(f-join treemacs-dir "test/testdir1")
@@ -1026,7 +1037,7 @@
     (-let [treemacs-collapse-dirs 3]
       (expect (-> treemacs-dir
                   (f-join "test/testdir1/testdir2")
-                  (treemacs--collapsed-dirs-process)
+                  (treemacs--collapsed-dirs-process (make-treemacs-project :name "P" :path treemacs-dir :path-status 'local-readable))
                   (treemacs--parse-collapsed-dirs))
               :to-be nil))))
 

--- a/test/test-treemacs.el
+++ b/test/test-treemacs.el
@@ -990,6 +990,24 @@
             :to-equal
             '("* Workspace" "** Project" " - path :: /x"))))
 
+(describe "treemacs--git-status-process"
+
+  (it "Does not call treemacs--git-status-process-function with non-local or unreadable paths"
+    (dolist (status '(local-unreadable remote-readable remote-unreadable remote-disconnected extension))
+      (spy-on 'treemacs--git-status-process-function)
+      (-> treemacs-dir
+          (f-join "test")
+          (treemacs--git-status-process (make-treemacs-project :name "P" :path treemacs-dir :path-status status)))
+      (expect 'treemacs--git-status-process-function
+              :not :to-have-been-called)))
+
+  (it "Calls treemacs--git-status-process-function with local readable path"
+    (spy-on 'treemacs--git-status-process-function)
+    (let ((path (f-join treemacs-dir "test")))
+      (treemacs--git-status-process path (make-treemacs-project :name "P" :path treemacs-dir :path-status 'local-readable))
+      (expect 'treemacs--git-status-process-function
+              :to-have-been-called-with path))))
+
 (describe "treemacs--parse-collapsed-dirs"
 
   (it "Finds dirs to flatten in test directory"

--- a/test/test-treemacs.el
+++ b/test/test-treemacs.el
@@ -67,29 +67,29 @@
 
     (it "Identifies that a path is in a project"
       (let ((path "~/P/A/B/C/D/E/F/file")
-            (project (make-treemacs-project :name "P" :path "~/P/A/B/C")))
+            (project (make-treemacs-project :name "P" :path "~/P/A/B/C" :path-status 'local-readable)))
         (expect (treemacs-is-path path :in-project project) :to-be-truthy)))
 
        (it "Identifies that a path is not in a project"
          (let ((path "~/X/abc")
-               (project (make-treemacs-project :name "P" :path "~/P")))
+               (project (make-treemacs-project :name "P" :path "~/P" :path-status 'local-readable)))
            (expect (treemacs-is-path path :in-project project) :not :to-be-truthy))))
 
   (describe ":in-workspace matcher"
 
     (it "Finds project of path in the workspace"
       (let* ((path "~/C/abc")
-             (p1 (make-treemacs-project :name "P1" :path "~/A"))
-             (p2 (make-treemacs-project :name "P2" :path "~/B"))
-             (p3 (make-treemacs-project :name "P3" :path "~/C"))
+             (p1 (make-treemacs-project :name "P1" :path "~/A" :path-status 'local-readable))
+             (p2 (make-treemacs-project :name "P2" :path "~/B" :path-status 'local-readable))
+             (p3 (make-treemacs-project :name "P3" :path "~/C" :path-status 'local-readable))
              (ws (make-treemacs-workspace :name "WS" :projects (list p1 p2 p3))))
         (expect (treemacs-is-path path :in-workspace ws) :to-be p3)))
 
     (it "Identifies path not in the workspace" ()
         (let* ((path "~/D/abc")
-               (p1 (make-treemacs-project :name "P1" :path "~/A"))
-               (p2 (make-treemacs-project :name "P2" :path "~/B"))
-               (p3 (make-treemacs-project :name "P3" :path "~/C"))
+               (p1 (make-treemacs-project :name "P1" :path "~/A" :path-status 'local-readable))
+               (p2 (make-treemacs-project :name "P2" :path "~/B" :path-status 'local-readable))
+               (p3 (make-treemacs-project :name "P3" :path "~/C" :path-status 'local-readable))
                (ws (make-treemacs-workspace :name "WS" :projects (list p1 p2 p3))))
           (expect (treemacs-is-path path :in-workspace ws) :to-be nil)))))
 
@@ -279,34 +279,34 @@
   (it "Does nothing when dotfiles are shown"
     (let ((treemacs-show-hidden-files t)
           (input '("/home/.A" "/home/B/C" "/home/.A/B" "/home/.A/.B/.C")))
-      (expect (treemacs--with-project (make-treemacs-project :path "/home")
+      (expect (treemacs--with-project (make-treemacs-project :path "/home" :path-status 'local-readable)
                 (treemacs--maybe-filter-dotfiles input))
               :to-equal input)))
 
   (it "Fails on nil input"
     (let ((treemacs-show-hidden-files nil))
-      (expect (treemacs--with-project (make-treemacs-project :path "/home")
+      (expect (treemacs--with-project (make-treemacs-project :path "/home" :path-status 'local-readable)
                 (treemacs--maybe-filter-dotfiles nil))
               :to-throw)))
 
   (it "Filters single dotfile"
     (let ((treemacs-show-hidden-files nil)
           (input '("/home/A/B/C/D/.d")))
-      (expect (treemacs--with-project (make-treemacs-project :path "/home")
+      (expect (treemacs--with-project (make-treemacs-project :path "/home" :path-status 'local-readable)
                 (treemacs--maybe-filter-dotfiles input))
               :to-be nil)))
 
   (it "Filters dotfile based on part"
     (let ((treemacs-show-hidden-files nil)
           (input '("/home/A/B/C/.D/d")))
-      (expect (treemacs--with-project (make-treemacs-project :path "/home")
+      (expect (treemacs--with-project (make-treemacs-project :path "/home" :path-status 'local-readable)
                 (treemacs--maybe-filter-dotfiles input))
               :to-be nil)))
 
   (it "Does not filter dotfile above root"
     (let ((treemacs-show-hidden-files nil)
           (input '("/home/.A/B/C/d")))
-      (expect (treemacs--with-project (make-treemacs-project :path "/home/.A/B")
+      (expect (treemacs--with-project (make-treemacs-project :path "/home/.A/B" :path-status 'local-readable)
                 (make-treemacs-workspace :projects (list ))
                 (treemacs--maybe-filter-dotfiles input))
               :to-equal input)))
@@ -314,7 +314,7 @@
   (it "Filters long input"
     (let ((treemacs-show-hidden-files nil)
           (input '("/home/.A/B/C/d" "/home/.A/B/.C/D/E" "/home/.A/B/C/.d" "/home/.A/B/C/D/E")))
-      (expect (treemacs--with-project (make-treemacs-project :path "/home/.A/B")
+      (expect (treemacs--with-project (make-treemacs-project :path "/home/.A/B" :path-status 'local-readable)
                 (treemacs--maybe-filter-dotfiles input))
               :to-equal '("/home/.A/B/C/d" "/home/.A/B/C/D/E")))))
 
@@ -772,7 +772,7 @@
 (describe "treemacs--find-project-for-path"
 
   (it "Returns nil when input is nil"
-    (treemacs--with-project (make-treemacs-project :path "/A")
+    (treemacs--with-project (make-treemacs-project :path "/A" :path-status 'local-readable)
       (expect (treemacs--find-project-for-path nil) :to-be nil)))
 
   (it "Returns nil when the workspace is empty"
@@ -780,11 +780,11 @@
       (expect (treemacs--find-project-for-path "/A") :to-be nil)))
 
   (it "Returns nil when path does not fit any project"
-    (treemacs--with-project (make-treemacs-project :path "/A/B")
+    (treemacs--with-project (make-treemacs-project :path "/A/B" :path-status 'local-readable)
       (expect (treemacs--find-project-for-path "/A/C") :to-be nil)))
 
   (it "Returns project when path fits"
-    (-let [project (make-treemacs-project :path "/A/B")]
+    (-let [project (make-treemacs-project :path "/A/B" :path-status 'local-readable)]
       (treemacs--with-project project
         (expect (treemacs--find-project-for-path "/A/B/C")
                 :to-equal project)))))

--- a/test/treemacs-test.el
+++ b/test/treemacs-test.el
@@ -43,7 +43,7 @@
             (let* ((imenu-auto-rescan t)
                    (org-imenu-depth 10)
                    (treemacs-collapse-dirs 3)
-                   (project (make-treemacs-project :name "Test Project" :path (concat treemacs-dir "/test")))
+                   (project (make-treemacs-project :name "Test Project" :path (concat treemacs-dir "/test") :path-status 'local-readable))
                    (workspace (make-treemacs-workspace :name "Test Workspace" :projects (list project)))
                    (workspaces treemacs--workspaces))
               (treemacs--with-workspace workspace


### PR DESCRIPTION
Currently, if a previously persisted project does not exist, Treemacs will remove it without prompting, and this change will be persisted when quitting Emacs. This becomes a problem when you happen to start Emacs without your network mounts and the only option for recovery is to `kill -9` Emacs.

This PR adds a new setting `treemacs-missing-project-action` with options `ask`, `remove`, and `keep`. Ask is the default, since deleting user's configuration without prompting is not very nice, and `keep` might leave users thinking that Treemacs is broken because a project suddenly refuses open.

Treemacs seems to handle missing directories pretty well, so I didn't add any state about existence to the project nodes.

The `ask` option will give an abort/retry/fail -style prompt, with options to keep, remove, or try again.

Additionally, `treemacs--restore` temporarily removes `treemacs--persist` from `emacs-kill-hook`, otherwise closing the Emacs window during the `ask` prompt would obliterate any persisted state. I'm not sure if this fixes other issues as well, i.e. if it was previously possible to kill Emacs during `treemacs--restore`.