### PR TITLE
[Extensions] Manage projects correctly with extensions

### DIFF
--- a/src/elisp/treemacs-impl.el
+++ b/src/elisp/treemacs-impl.el
@@ -551,11 +551,13 @@ Add a project for ROOT and NAME if they are non-nil."
          (setq current-workspace (treemacs-current-workspace))
          (run-hook-with-args treemacs-workspace-first-found-functions
                              current-workspace (selected-frame)))
-       (if (treemacs-workspace->is-empty?)
-           (-> (treemacs--read-first-project-path)
-               (treemacs--canonical-path)
-               (treemacs-do-add-project-to-workspace))
-         (treemacs--render-projects (treemacs-workspace->projects current-workspace)))
+       ;; Render the projects even if there are none. This ensures that top-level
+       ;; extensions are always rendered, and the project markers are initialized.
+       (treemacs--render-projects (treemacs-workspace->projects current-workspace))
+       (when (treemacs-workspace->is-empty?)
+         (-> (treemacs--read-first-project-path)
+             (treemacs--canonical-path)
+             (treemacs-do-add-project-to-workspace)))
        (goto-char 2)))
     (when root (treemacs-do-add-project-to-workspace (treemacs--canonical-path root) name))
     (with-no-warnings (setq treemacs--ready-to-follow t))


### PR DESCRIPTION
**Problems**
- New projects are not inserted between top-level extensions
- Inserting a project clears the DOM if there are no other projects, but DOM might have extension-related data
- When there are no projects, separators are rendered incorrectly between top-level extensions
- When top-level extensions' predicate says no, whitespace might be rendered incorrectly
- When there are no projects, top-level extensions are not rendered.

**Solution**
 Keep a marker for the project add position, at the EOL of the last project. If no projects, at the EOL of the first extension positioned at 'top. When no extension, at BOB and not moving with insertion.
- When adding the first project, don't reset DOM because it might still contain extension-related data.
- Always render the projects, even when there are no projects, since  extensions might still be shown.
- Take into account the possiblity that nothing might follow or precede top-level expansions when adding the separator.
- Correctly handle top-level extension separators when the predicate  returns false.
- Extract separator insertion into an inlined function.
- When adding the first project, don't reset DOM because it might still contain extension-related data. **I'm not sure if there's a reason for clearing the DOM when adding the first project?**