### PR TITLE
[Git] Fix errors in find_recursive_entries

### DIFF
--- a/src/scripts/treemacs-git-status.py
+++ b/src/scripts/treemacs-git-status.py
@@ -1,6 +1,6 @@
 from subprocess import Popen, PIPE
 from os import listdir
-from os.path import isdir
+from os.path import isdir, islink
 from posixpath import join
 import sys
 
@@ -31,7 +31,7 @@ def find_recursive_entries(path, state):
         ht_size += 1
         if ht_size > LIMIT:
             break
-        if isdir(full_path):
+        if isdir(full_path) and not islink(full_path):
             find_recursive_entries(full_path, state)
 
 def main():

--- a/src/scripts/treemacs-git-status.py
+++ b/src/scripts/treemacs-git-status.py
@@ -32,7 +32,7 @@ def find_recursive_entries(path, state):
         if ht_size > LIMIT:
             break
         if isdir(full_path):
-            find_recursive_entries(full_path)
+            find_recursive_entries(full_path, state)
 
 def main():
     global output, ht_size


### PR DESCRIPTION
There was an argument missing in `find_recursive_entries`. 

Additionally, if the expanded directory contained a symlink loop, `treemacs-git-status.py` would hang indefinitely. Might <span>fix</span> #379 at least for some cases. This solution loses information about files behind symlinks though.