### PR TITLE
[Core] Fix treemacs-goto-node and treemacs-find-node

### DIFF
--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -901,9 +901,8 @@ successful.
 PATH: Filepath | Node Path
 PROJECT Project Struct"
   (cond
-   ((and (stringp path)
-         (file-exists-p path))
-    (treemacs-find-file-node path project))
+   ((stringp path)
+    (when (file-exists-p path) (treemacs-find-file-node path project)))
    ((eq :custom (car path))
     (treemacs--find-custom-top-level-node path))
    ((stringp (car path))
@@ -919,9 +918,8 @@ point.
 PATH: Filepath | Node Path
 PROJECT Project Struct"
   (cond
-   ((and (stringp path)
-         (file-exists-p path))
-    (treemacs-goto-file-node path project))
+   ((stringp path)
+    (when (file-exists-p path) (treemacs-goto-file-node path project)))
    ((eq :custom (car path))
     (treemacs--goto-custom-top-level-node path))
    ((stringp (car path))


### PR DESCRIPTION
Non-existent string paths should return nil rather than executing default case of finding a custom project node.

Can be tested with `(treemacs-goto-node "something-that-does-not-exists")` and the same for `treemacs-find-node`. Previouly this raised an error.