### PR TITLE
[Compatibilty] Fix Emacs 25

### DIFF
--- a/src/elisp/treemacs-macros.el
+++ b/src/elisp/treemacs-macros.el
@@ -476,7 +476,7 @@ treemacs buffer exists at all, BODY will be executed."
 IGNORED-ERRORS is a list of errors to ignore.  Each element is a list whose car
 is the error's type, and second item is a regex to match against error messages.
 If any of the IGNORED-ERRORS matches, the error is suppressed and nil returned."
-  (let ((err (gensym)))
+  (let ((err (make-symbol "err")))
     `(condition-case-unless-debug ,err
          ,(macroexp-progn body)
        ,@(mapcar


### PR DESCRIPTION
Turns out that I broke Emacs 25. Emacs 25 does not have gensym by default, use make-symbol.