### PR TITLE
[Git] Fix handling of Git script warnings

### DIFF
--- a/src/elisp/treemacs-async.el
+++ b/src/elisp/treemacs-async.el
@@ -155,7 +155,12 @@ GIT-FUTURE: Pfuture"
         (-let [git-output (pfuture-await-to-finish git-future)]
           (when (= 0 (process-exit-status git-future))
             (-let [parsed-output (read git-output)]
-              (when (hash-table-p parsed-output) parsed-output)))))
+              (if (hash-table-p parsed-output)
+                  parsed-output
+                (let ((inhibit-message t))
+                  (treemacs-log "treemacs-git-status.py output: %s" git-output))
+                (treemacs-log "treemacs-git-status.py did not output a valid hash table. See Messages buffer for details.")
+                nil)))))
       (ht)))
 
 (defun treemacs--git-status-process-simple (path)

--- a/src/elisp/treemacs-async.el
+++ b/src/elisp/treemacs-async.el
@@ -151,13 +151,12 @@ The real parsing and formatting is done by the python process. All that's really
 left to do is pick up the cons list and put it in a hash table.
 
 GIT-FUTURE: Pfuture"
-  (-let [ret (ht)]
-    (when git-future
-      (pfuture-await-to-finish git-future)
-      (when (= 0 (process-exit-status git-future))
-        (-let [git-output (pfuture-result git-future)]
-          (setf ret (read git-output)))))
-    ret))
+  (or (when git-future
+        (-let [git-output (pfuture-await-to-finish git-future)]
+          (when (= 0 (process-exit-status git-future))
+            (-let [parsed-output (read git-output)]
+              (when (hash-table-p parsed-output) parsed-output)))))
+      (ht)))
 
 (defun treemacs--git-status-process-simple (path)
   "Start a simple git status process for files under PATH."


### PR DESCRIPTION
Currently, when `git status` gives a warning, e.g. `warning: could not open directory 'treemacs/.cask/25.3/elpa/gnupg/': Permission denied`, Treemacs `(read)`s this as `'warning:`. This causes a type error, making all files below the directory disappear from Treemacs. This pull

- Redirects git's `stderr` to `/dev/null` (using Python's `subprocess.DEVNULL`, so I'm at least guessing it will work on Windows), and
- Checks that the parsed output is a hash table.

**Edit:** I made this into two commits, in case you don't want the `stderr` one since it might make debugging some problems harder. If you want both commits, I can squeeze them to one if you want.

**Edit 2:** Fixes #314

**Edit 3:** Only including the `stderr` commit means that other warnings printed by Python could trigger the issue. Only including the parse result checking would not make the files disappear, but Git status would not be shown.