### PR TITLE
[Git] Fix handling of Git script warnings v2

### DIFF
--- a/src/elisp/treemacs.el
+++ b/src/elisp/treemacs.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2018 Alexander Miller
 
 ;; Author: Alexander Miller <alexanderm@web.de>
-;; Package-Requires: ((emacs "25.2") (cl-lib "0.5") (dash "2.11.0") (s "1.10.0") (f "0.11.0") (ace-window "0.9.0") (pfuture "1.6") (hydra "0.13.2") (ht "2.2"))
+;; Package-Requires: ((emacs "25.2") (cl-lib "0.5") (dash "2.11.0") (s "1.10.0") (f "0.11.0") (ace-window "0.9.0") (pfuture "1.7") (hydra "0.13.2") (ht "2.2"))
 ;; Homepage: https://github.com/Alexander-Miller/treemacs
 ;; Version: 2.5
 


### PR DESCRIPTION
* If pfuture-stderr is fbound, use it and show stderr to the user.
* If pfuture-result does not parse as a hash table, show a message to the user rather than causing an error.

With the current master of pfuture this discards git script output if it does not parse as a hash table.
With [this version](https://github.com/Alexander-Miller/pfuture/pull/5), it keeps working even when Git prints warnings to stderr. stderr is logged with messages.