### PR TITLE
[Git] Don't lock Git index when updating status

### DIFF
--- a/src/elisp/treemacs-async.el
+++ b/src/elisp/treemacs-async.el
@@ -162,6 +162,7 @@ GIT-FUTURE: Pfuture"
 (defun treemacs--git-status-process-simple (path)
   "Start a simple git status process for files under PATH."
   (let* ((default-directory (f-canonical path))
+         (process-environment (cons "GIT_OPTIONAL_LOCKS=0" process-environment))
          (future (pfuture-new "git" "status" "--porcelain" "--ignored" "-z" ".")))
     (process-put future 'default-directory default-directory)
     future))

--- a/src/scripts/treemacs-git-status.py
+++ b/src/scripts/treemacs-git-status.py
@@ -1,5 +1,5 @@
 from subprocess import Popen, PIPE
-from os import listdir
+from os import listdir, environ
 from os.path import isdir, islink
 from posixpath import join
 import sys
@@ -36,6 +36,8 @@ def find_recursive_entries(path, state):
 
 def main():
     global output, ht_size
+    # Don't lock Git when updating status.
+    environ["GIT_OPTIONAL_LOCKS"] = "0"
     proc = Popen(GIT_CMD, shell=True, stdout=PIPE, bufsize=100)
     dirs_added = {}
 


### PR DESCRIPTION
Set GIT_OPTIONAL_LOCKS=0 in environment. Don't use --no-optional-locks, since it is only available in Git 2.14. This prevents errors with simultaneous git commands running alongside git status.