### PR TITLE
[Core] Fix updating of custom root-level nodes

### DIFF
--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -819,7 +819,9 @@ failed.  PROJECT is used for determining whether Git actions are appropriate."
                     (treemacs-dom-node->position dom-node)
                   (treemacs-project->position root-key)))
            ;; do the rest manually
-           (search-result (if manual-parts (treemacs--follow-path-elements btn manual-parts) btn)))
+           (search-result (if manual-parts
+                              (treemacs--follow-path-elements btn manual-parts)
+                            (goto-char btn))))
       (if (eq 'follow-failed search-result)
           (prog1 nil
             (goto-char start))


### PR DESCRIPTION
`treemacs--find-custom-top-level-node` must go to the node even if it is in DOM.

Otherwise, if a child node of a top-level extension is updated, `treemacs-do-update-node` tries to update the top-level node with the update tab action of its child. 