### PR TITLE
Quote paths to commands that may contain spaces

### DIFF
--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -31,7 +31,7 @@
            (s-trim)
            (s-lines)
            (--first
-            (->> (concat it " --version")
+            (->> (concat (shell-quote-argument it) " --version")
                  (shell-command-to-string)
                  (s-trim)
                  (s-replace "Python " "")


### PR DESCRIPTION
Previous code fails with:

version-to-list: Invalid version syntax: ‘'c:\Program' is not recognized as an internal or external command,
operable program or batch file.’ (must start with a number)

if the Python binary is in a path with a space, e.g. "c:\Program Files\...".

Quote the path with `shell-quote-argument` to fix this.