### PR TITLE
Make tag-follow-mode more robust in the presence of extensions

### DIFF
--- a/src/elisp/treemacs-tag-follow-mode.el
+++ b/src/elisp/treemacs-tag-follow-mode.el
@@ -229,10 +229,10 @@ PROJECT: Project Struct"
                              (not (eq (car treemacs--previously-followed-tag-position) btn)))
                     (-let [(prev-followed-pos . prev-followed-path) treemacs--previously-followed-tag-position]
                       (save-excursion
-                        (goto-char prev-followed-pos)
-                        (when  (and (treemacs-is-path (-some-> (treemacs-current-button) (treemacs-button-get :path))
-                                                      :same-as prev-followed-path)
-                                    (eq 'file-node-open (treemacs-button-get prev-followed-pos :state)))
+                        (when (marker-position prev-followed-pos) (goto-char prev-followed-pos))
+                        (when  (and (eq 'file-node-open (treemacs-button-get prev-followed-pos :state))
+                                    (treemacs-is-path (-some-> (treemacs-current-button) (treemacs-button-get :path))
+                                                      :same-as prev-followed-path))
                           (treemacs--collapse-file-node prev-followed-pos)))))
                   ;; when that doesnt work move manually to the correct file
                   (-let [btn-path (treemacs-button-get btn :path)]


### PR DESCRIPTION
When using (top level) extensions, treemacs can display nodes that are
neither tag nor file nodes.  And tag-follow-mode can end up saving one
of those nodes as its
treemacs--previously-followed-tag-position (imagine or instance a
buffer-follow-mode with an extension that lists buffers).  The code
modified here assumes that that cannot happen and the button at hand
must then be always a file node with a string :path, which leads to an
exception when treemacs-is-path uses string= on a path that is not a
string (because it's the path of, say, a buffer node).

I hope that makes sense.

The fix is trivial: just check first the kind of node, then its path.

I've also seen errors where the previous position wasn't valid, and
that's why i'm protecting the goto-char... i cannot reproduce them
reliably and they might well be due to other reasons, so maybe that
modification, altough harmless, is unnecessary.