### PR TITLE
[Core][Extensions] Fixes to update node

### DIFF
--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -1127,11 +1127,15 @@ Valid states are 'visible, 'exists and 'none."
   (declare (pure t) (side-effect-free t))
   (inline-letevals (path)
     (inline-quote
-     (if (treemacs-is-path ,path :same-as "/")
-         ,path
-       (-> ,path
-           (file-name-directory)
-           (treemacs--unslash))))))
+     (treemacs-with-path ,path
+       :file-action (if (treemacs-is-path ,path :same-as "/")
+                        ,path
+                      (-> ,path
+                          (file-name-directory)
+                          (treemacs--unslash)))
+       :top-level-extension-action (when (> (length ,path) 2) (butlast ,path))
+       :directory-extension-action (if (> (length ,path) 2) (butlast ,path) (car ,path))
+       :project-extension-action (if (> (length ,path) 2) (butlast ,path) (treemacs-project->path (car ,path)))))))
 
 (defun treemacs--evade-image ()
   "The cursor visibly blinks when on top of an icon.

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -922,15 +922,12 @@ successful.
 
 PATH: Filepath | Node Path
 PROJECT Project Struct"
-  (cond
-   ((stringp path)
-    (when (file-exists-p path) (treemacs-find-file-node path project)))
-   ((eq :custom (car path))
-    (treemacs--find-custom-top-level-node path))
-   ((stringp (car path))
-    (treemacs--find-custom-dir-node path))
-   (t
-    (treemacs--find-custom-project-node path))))
+  (treemacs-with-path path
+    :file-action (when (file-exists-p path)
+                   (treemacs-find-file-node path project))
+    :top-level-extension-action (treemacs--find-custom-top-level-node path)
+    :directory-extension-action (treemacs--find-custom-dir-node path)
+    :project-extension-action (treemacs--find-custom-project-node path)))
 
 (defun treemacs-goto-node (path &optional project)
   "Move point to button identified by PATH under PROJECT in the current buffer.
@@ -939,15 +936,11 @@ point.
 
 PATH: Filepath | Node Path
 PROJECT Project Struct"
-  (cond
-   ((stringp path)
-    (when (file-exists-p path) (treemacs-goto-file-node path project)))
-   ((eq :custom (car path))
-    (treemacs--goto-custom-top-level-node path))
-   ((stringp (car path))
-    (treemacs--goto-custom-dir-node path))
-   (t
-    (treemacs--goto-custom-project-node path))))
+  (treemacs-with-path path
+    :file-action (when (file-exists-p path) (treemacs-goto-file-node path project))
+    :top-level-extension-action (treemacs--goto-custom-top-level-node path)
+    :directory-extension-action (treemacs--goto-custom-dir-node path)
+    :project-extension-action (treemacs--goto-custom-project-node path)))
 
 (defun treemacs-find-file-node (path &optional project)
   "Find position of node identified by PATH under PROJECT in the current buffer.

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -861,7 +861,8 @@ failed.  PROJECT is used for determining whether Git actions are appropriate."
                             (treemacs-dom-node->position dom-node)
                           (treemacs-project->position project)))
                    ;; do the rest manually
-                   (search-result (if manual-parts (treemacs--follow-path-elements btn manual-parts) btn)))
+                   (search-result (if manual-parts (treemacs--follow-path-elements btn manual-parts)
+                                    (goto-char btn))))
               (if (eq 'follow-failed search-result)
                   (prog1 nil
                     (goto-char start))
@@ -986,7 +987,9 @@ PROJECT: Project Struct"
                     (treemacs-project->position project)
                   (treemacs-dom-node->position dom-node)))
            ;; do the rest manually - at least the actual file to move to is still left in manual-parts
-           (search-result (if manual-parts (save-match-data (treemacs--follow-each-dir btn manual-parts project)) btn)))
+           (search-result (if manual-parts (save-match-data
+                                             (treemacs--follow-each-dir btn manual-parts project))
+                            (goto-char btn))))
       (if (eq 'follow-failed search-result)
           (prog1 nil
             (goto-char start))

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -879,18 +879,12 @@ Unlike `treemacs-find-node' this will not expand other nodes in the view, but
 only look among those currently visible. The result however is the same: either
 a marker ponting to the found node or nil.
 
+Unlike `treemacs-find-node', this function does not go to the node.
+
 PATH: Node Path"
-  (-let [node (treemacs-find-in-dom path)]
-    ;; just finding a node in the dom is far from enough to be sure it is visible
-    ;; it can still be closed with children, or be one of the children of a closed node
-    (if (and node
-             (treemacs-dom-node->position node)
-             (null (treemacs-dom-node->closed node)))
-        (treemacs-dom-node->position node)
-      (-when-let (parent (treemacs-find-in-dom (treemacs--parent path)))
-        (when (treemacs-dom-node->position parent)
-          (treemacs-first-child-node-where (treemacs-dom-node->position parent)
-            (treemacs-is-path path :same-as (treemacs-button-get child-btn :path))))))))
+  (when (treemacs-is-path-visible? path)
+    (save-excursion
+      (treemacs-find-node path))))
 
 (defun treemacs-find-node (path &optional project)
   "Find position of node identified by PATH under PROJECT in the current buffer.
@@ -923,8 +917,7 @@ successful.
 PATH: Filepath | Node Path
 PROJECT Project Struct"
   (treemacs-with-path path
-    :file-action (when (file-exists-p path)
-                   (treemacs-find-file-node path project))
+    :file-action (when (file-exists-p path) (treemacs-find-file-node path project))
     :top-level-extension-action (treemacs--find-custom-top-level-node path)
     :directory-extension-action (treemacs--find-custom-dir-node path)
     :project-extension-action (treemacs--find-custom-project-node path)))

--- a/src/elisp/treemacs-rendering.el
+++ b/src/elisp/treemacs-rendering.el
@@ -623,7 +623,7 @@ FORCE-EXPAND: Boolean"
          (-let [close-func (alist-get (treemacs-button-get btn :state) treemacs-TAB-actions-config)]
            (funcall close-func)
            ;; close node again if no new lines were rendered
-           (when (= 1 (funcall (alist-get (treemacs-button-get btn :state) treemacs-TAB-actions-config)))
+           (when (eq 1 (funcall (alist-get (treemacs-button-get btn :state) treemacs-TAB-actions-config)))
              (funcall close-func)))
          (when ,force-expand
            (funcall (alist-get (treemacs-button-get btn :state) treemacs-TAB-actions-config))))))))

--- a/test/test-treemacs.el
+++ b/test/test-treemacs.el
@@ -333,7 +333,24 @@
     (expect (treemacs--parent "/home/A/B") :to-equal "/home/A"))
 
   (it "Returns the system root when it's the input"
-    (expect (treemacs--parent "/") :to-equal "/")))
+    (expect (treemacs--parent "/") :to-equal "/"))
+
+  (it "Returns parent of root-level extension node."
+    (expect (treemacs--parent '(:custom "a" "b")) :to-equal '(:custom "a")))
+
+  (it "Returns directory extension of extension sub-item node."
+    (expect (treemacs--parent '("/test1" "a" "b")) :to-equal '("/test1" "a")))
+
+  (it "Returns directory of a directory extension node."
+    (expect (treemacs--parent '("/test1" "a")) :to-equal "/test1"))
+
+  (it "Returns project extension of a project sub-item node."
+    (let ((p (make-treemacs-project :path "/A" :path-status 'local-readable)))
+      (expect (treemacs--parent (list p "a" "b")) :to-equal (list p "a"))))
+
+  (it "Returns project of a project extension node."
+    (let ((p (make-treemacs-project :path "/A" :path-status 'local-readable)))
+      (expect (treemacs--parent (list p "a")) :to-equal "/A"))))
 
 (describe "treemacs--get-or-parse-git-result"
 


### PR DESCRIPTION
* `treemacs-update-node` now work with file nodes
* `treemacs-update-node` ignores hidden nodes, setting their `treemacs-dom-node->refresh-flag` instead.
* **Semantic change: `treemacs-update-node` silently ignores non-existent nodes. This is because extensions cannot know what extension nodes have been displayed. E.g. Treemacs Bookmark has to update all ancestors of a bookmarked path, even when the directory is not open in Treemacs.**
* `treemacs-is-path-visible?` fixed to check that all DOM ancestors are expanded instead of only checking that the node is in DOM.
* `treemacs-is-path-visible?` works with all kinds of nodes.
* **Semantic change: return type of `treemacs-is-node-visible?`  is now boolean, since collapsed non-variadic top-level nodes don't exist in DOM.**
* `treemacs--parent` works with all kinds of nodes.
* New macro `treemacs-with-path` to perform operations on different kinds of path. `treemacs--parent` uses it. In addition `treemacs-goto-node` and `treemacs-find-node` were updated to use it.