### PR TITLE
Add trailing '/' so that `f-move` doesn't throw any error

### DIFF
--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -1318,7 +1318,7 @@ from `treemacs-copy-file' or `treemacs-move-file'."
        (treemacs-error-return-if (not (treemacs-is-node-file-or-dir? node))
          wrong-type-msg)
        (let* ((source (treemacs-button-get node :path))
-              (destination (read-directory-name prompt nil default-directory :must-match))
+              (destination (file-name-as-directory (read-directory-name prompt nil default-directory :must-match)))
               (filename (treemacs--filename source))
               (move-to-on-success (f-join destination filename)))
          (when (file-exists-p (f-join destination filename))


### PR DESCRIPTION
This bug occurs when read-directory-name opens a GUI dialog box and
asks for a directory. This way the selected directory doesn't end with
a trailing '/'. This commit fixes that.

Reproduction steps:

1. Open Right Click menu
2. Click on *Move*

This will bring up the GUI dialog box. Choose a destination directory
and confirm. This will throw an error without this commit.