### PR TITLE
[Extensions] Fix variadic extensions positioned at top

### DIFF
--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -464,7 +464,13 @@ Will also perform cleanup if the buffer is dead."
      (when ,btn
        (let ((depth (treemacs-button-get ,btn :depth))
              (next (next-button (treemacs-button-end ,btn) t)))
-         (while (and next (< depth (treemacs-button-get next :depth)))
+         (while (and next
+                     (< depth (treemacs-button-get next :depth))
+                     ;; Special handling for variadic hidden nodes.
+                     ;; Since they are at negative depth, projects would be considered their children.
+                     (or (>= depth 0)
+                         (and (consp (treemacs-button-get next :path))
+                              (-is-prefix? (treemacs-button-get ,btn :path) (treemacs-button-get next :path)))))
            (setq next (next-button (treemacs-button-end next) t)))
          next)))))
 

--- a/src/elisp/treemacs-extensions.el
+++ b/src/elisp/treemacs-extensions.el
@@ -453,29 +453,28 @@ additional keys."
                     ;; node. Its depth is -1 and it is not visible, but can still be used to update
                     ;; the entire extension without explicitly worrying about complex dom changes.
                     `(defun ,ext-name ()
-                         (treemacs-with-writable-buffer
-                          (save-excursion
-                            (let ((pr (make-treemacs-project
-                                       :name ,root-label
-                                       :path ,root-key-form
-                                       :path-status 'extension))
-                                  (button-start (point-marker)))
-                              (treemacs--set-project-position ,root-key-form (point-marker))
-                              (insert (propertize "Hidden Node\n"
-                                                  'button '(t)
-                                                  'category 'default-button
-                                                  'invisible t
-                                                  'skip t
-                                                  :custom t
-                                                  :key ,root-key-form
-                                                  :path (list :custom ,root-key-form)
-                                                  :depth -1
-                                                  :project pr
-                                                  :state ,closed-state-name))
-                              (let ((marker (copy-marker (point) t)))
-                                (funcall ',do-expand-name button-start)
-                                (goto-char marker)))))
-                         t)
+                       (treemacs-with-writable-buffer
+                        (let ((pr (make-treemacs-project
+                                   :name ,root-label
+                                   :path ,root-key-form
+                                   :path-status 'extension))
+                              (button-start (point-marker)))
+                          (treemacs--set-project-position ,root-key-form  (point-marker))
+                          (insert (propertize "Hidden Node\n"
+                                              'button '(t)
+                                              'category 'default-button
+                                              'invisible t
+                                              'skip t
+                                              :custom t
+                                              :key ,root-key-form
+                                              :path (list :custom ,root-key-form)
+                                              :depth -1
+                                              :project pr
+                                              :state ,closed-state-name))
+                          (let ((marker (copy-marker (point) t)))
+                            (funcall ',do-expand-name button-start)
+                            (goto-char marker))))
+                       t)
                   `(progn
                      (defun ,ext-name (&rest _)
                        (treemacs-with-writable-buffer


### PR DESCRIPTION
This fixes the positioning of variadic extensions at top by removing a `save-excursion`. The `save-excursion` made the point be before the variadic root-level nodes, causing projects to always be inserted before the extension nodes.