### PR TITLE
[Extensions] Fix variadic extensions at top, version 2

### DIFF
--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -340,11 +340,10 @@ Returns nil if no such buffer exists.."
   "Replace icon in current line with NEW-SYM."
   (inline-letevals (new-sym)
     (inline-quote
-     (save-excursion
-       (let ((len (length ,new-sym)))
-         (goto-char (- (treemacs-button-start (next-button (point-at-bol) t)) len))
-         (insert ,new-sym)
-         (delete-char len))))))
+     (let* ((icon-start (text-property-any (line-beginning-position) (line-end-position) 'icon t))
+            (icon-end (next-single-property-change icon-start 'icon))
+            (new-properties (text-properties-at 0 ,new-sym)))
+       (add-text-properties icon-start icon-end new-properties)))))
 
 (defun treemacs-project-of-node (node)
   "Find the project the given NODE belongs to."

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -463,7 +463,14 @@ Will also perform cleanup if the buffer is dead."
      (when ,btn
        (let ((depth (treemacs-button-get ,btn :depth))
              (next (next-button (treemacs-button-end ,btn) t)))
-         (while (and next (< depth (treemacs-button-get next :depth)))
+         (while (and next
+                     (< depth (treemacs-button-get next :depth))
+                     (or (>= depth 0)
+                         ;; Special handling for variadic extension roots whose
+                         ;; depth is -1.
+                         (let ((next-path (treemacs-button-get next :path)))
+                           (and (listp next-path)
+                                (-is-prefix? (treemacs-button-get ,btn :path) next-path)))))
            (setq next (next-button (treemacs-button-end next) t)))
          next)))))
 

--- a/src/elisp/treemacs-extensions.el
+++ b/src/elisp/treemacs-extensions.el
@@ -190,21 +190,20 @@ MORE-PROPERTIES is a plist of text properties that can arbitrarily added to the
 node for quick retrieval later."
   (treemacs-static-assert (and icon label-form state key-form)
     "All values except :more-properties and :face are mandatory")
-  `(concat (unless (zerop depth) prefix)
-           ,icon
-           (propertize ,label-form
-                       'button '(t)
-                       'category 'default-button
-                       ,@(when face `((quote face) ,face))
-                       'help-echo nil
-                       :custom t
-                       :state ,state
-                       :parent node
-                       :depth depth
-                       :path (append (treemacs-button-get node :path) (list ,key-form))
-                       :key ,key-form
-                       ,@more-properties)
-           (when (and (zerop depth) treemacs-space-between-root-nodes) "\n")))
+  `(concat
+    (propertize (concat prefix ,icon ,label-form)
+                'button '(t)
+                'category 'default-button
+                ,@(when face `((quote face) ,face))
+                'help-echo nil
+                :custom t
+                :state ,state
+                :parent node
+                :depth depth
+                :path (append (treemacs-button-get node :path) (list ,key-form))
+                :key ,key-form
+                ,@more-properties)
+    (when (and (zerop depth) treemacs-space-between-root-nodes) "\n")))
 
 (cl-defmacro treemacs-define-leaf-node (name icon &key ret-action tab-action mouse1-action visit-action)
   "Define a type of node that is a leaf and cannot be further expanded.
@@ -420,9 +419,10 @@ additional keys."
           `(cl-defun ,(intern (format "treemacs-%s-extension" (upcase (symbol-name name)))) (parent)
              (-let [depth (1+ (treemacs-button-get parent :depth))]
                (insert
-                (treemacs--get-indentation depth)
-                ,(if icon-closed closed-icon-name icon-closed-form)
-                (propertize ,root-label
+                (propertize (concat
+                             (treemacs--get-indentation depth)
+                             ,(if icon-closed closed-icon-name icon-closed-form)
+                             ,root-label)
                             'button '(t)
                             'category 'default-button
                             'face ,root-face
@@ -475,9 +475,10 @@ additional keys."
                                    :name ,root-label
                                    :path ,root-key-form
                                    :path-status 'extension)]
-                          (insert ,(if icon-closed closed-icon-name icon-closed-form))
                           (treemacs--set-project-position ,root-key-form (point-marker))
-                          (insert (propertize ,root-label
+                          (insert (propertize (concat
+                                               ,(if icon-closed closed-icon-name icon-closed-form)
+                                               ,root-label)
                                               'button '(t)
                                               'category 'default-button
                                               'face ,root-face

--- a/src/elisp/treemacs-extensions.el
+++ b/src/elisp/treemacs-extensions.el
@@ -202,8 +202,7 @@ node for quick retrieval later."
                 :depth depth
                 :path (append (treemacs-button-get node :path) (list ,key-form))
                 :key ,key-form
-                ,@more-properties)
-    (when (and (zerop depth) treemacs-space-between-root-nodes) "\n")))
+                ,@more-properties)))
 
 (cl-defmacro treemacs-define-leaf-node (name icon &key ret-action tab-action mouse1-action visit-action)
   "Define a type of node that is a leaf and cannot be further expanded.
@@ -449,46 +448,49 @@ additional keys."
                     ;; the entire extension without explicitly worrying about complex dom changes.
                     `(defun ,ext-name ()
                        (treemacs-with-writable-buffer
-                        (save-excursion
-                          (let ((pr (make-treemacs-project
-                                     :name ,root-label
-                                     :path ,root-key-form
-                                     :path-status 'extension))
-                                (button-start (point-marker)))
-                            (treemacs--set-project-position ,root-key-form (point-marker))
-                            (insert (propertize "Hidden Node\n"
-                                                'button '(t)
-                                                'category 'default-button
-                                                'invisible t
-                                                'skip t
-                                                :custom t
-                                                :key ,root-key-form
-                                                :path (list :custom ,root-key-form)
-                                                :depth -1
-                                                :project pr
-                                                :state ,closed-state-name))
-                            (funcall ',do-expand-name button-start)))))
-                  `(progn
-                     (defun ,ext-name (&rest _)
-                       (treemacs-with-writable-buffer
-                        (-let [pr (make-treemacs-project
+                        (let ((pr (make-treemacs-project
                                    :name ,root-label
                                    :path ,root-key-form
-                                   :path-status 'extension)]
+                                   :path-status 'extension))
+                              (button-start (point-marker)))
                           (treemacs--set-project-position ,root-key-form (point-marker))
-                          (insert (propertize (concat
-                                               ,(if icon-closed closed-icon-name icon-closed-form)
-                                               ,root-label)
+                          (insert (propertize "Hidden Node"
                                               'button '(t)
                                               'category 'default-button
-                                              'face ,root-face
+                                              'invisible t
+                                              'skip t
                                               :custom t
                                               :key ,root-key-form
                                               :path (list :custom ,root-key-form)
-                                              :depth 0
+                                              :depth -1
                                               :project pr
-                                              :state ,closed-state-name))
-                          (treemacs--insert-root-separator))))))))))))
+                                              :state ,closed-state-name)
+                                  ;; Insert the newline separately so that it is
+                                  ;; not part of the button.
+                                  (propertize "\n" 'invisible t))
+                          (let ((marker (copy-marker (point) t)))
+                            (funcall ',do-expand-name button-start)
+                            (goto-char marker)))))
+                  `(defun ,ext-name (&rest _)
+                     (treemacs-with-writable-buffer
+                      (-let [pr (make-treemacs-project
+                                 :name ,root-label
+                                 :path ,root-key-form
+                                 :path-status 'extension)]
+                        (treemacs--set-project-position ,root-key-form (point-marker))
+                        (insert (propertize (concat
+                                             ,(if icon-closed closed-icon-name icon-closed-form)
+                                             ,root-label)
+                                            'button '(t)
+                                            'category 'default-button
+                                            'face ,root-face
+                                            :custom t
+                                            :key ,root-key-form
+                                            :path (list :custom ,root-key-form)
+                                            :depth 0
+                                            :project pr
+                                            :state ,closed-state-name))
+                        (treemacs--insert-root-separator)))))))))))
 
 (cl-defmacro treemacs-define-variadic-node
     (name &key

--- a/src/elisp/treemacs-icons.el
+++ b/src/elisp/treemacs-icons.el
@@ -101,9 +101,10 @@ Necessary since root icons are not rectangular."
                 (concat (propertize " "
                                     'display img-unselected
                                     'img-selected img-selected
-                                    'img-unselected img-unselected)
+                                    'img-unselected img-unselected
+                                    'icon t)
                         " ")))))
-       (cons gui-icon tui-icon)))))
+       (cons gui-icon (propertize tui-icon 'icon t))))))
 
 (defmacro treemacs--splice-icon (icon)
   "Splice the given ICON data depending on whether it is a value or an sexp."

--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -345,19 +345,24 @@ If there is no node at point use \"~/\" instead.
 Also skip hidden buttons (as employed by variadic extensions).
 
 Used as a post command hook."
-  (-when-let (btn (treemacs-current-button))
-    (when (treemacs-button-get btn 'invisible)
-      (treemacs-next-line 1))
-    (-if-let* ((project (treemacs-project-of-node btn))
-               (path (or (treemacs-button-get btn :default-directory)
-                         (treemacs--nearest-path btn))))
-        (when (and (treemacs-project->is-readable? project)
-                   (file-readable-p path))
-          (setq treemacs--eldoc-msg path
-                default-directory (treemacs--add-trailing-slash
-                                   (if (file-directory-p path) path (file-name-directory path)))))
-      (setq treemacs--eldoc-msg nil
-            default-directory "~/"))))
+  (-if-let (btn (treemacs-current-button))
+      (progn
+        (when (treemacs-button-get btn 'invisible)
+          (treemacs-next-line 1))
+        (-if-let* ((project (treemacs-project-of-node btn))
+                   (path (or (treemacs-button-get btn :default-directory)
+                             (treemacs--nearest-path btn))))
+            (when (and (treemacs-project->is-readable? project)
+                       (file-readable-p path))
+              (setq treemacs--eldoc-msg path
+                    default-directory (treemacs--add-trailing-slash
+                                       (if (file-directory-p path) path (file-name-directory path)))))
+          (setq treemacs--eldoc-msg nil
+                default-directory "~/")))
+    ;; If moved to the newlines at the end of the buffer,
+    ;; move to the previous button.
+    (when (> (point) (- (point-max) 2))
+      (treemacs-previous-line 1))))
 
 (defun treemacs--eldoc-function ()
   "Treemacs' implementation of `eldoc-documentation-function'.

--- a/src/elisp/treemacs-rendering.el
+++ b/src/elisp/treemacs-rendering.el
@@ -182,21 +182,19 @@ GIT-INFO is the git info of the current directory."
   (inline-letevals (path prefix parent depth git-info)
     (inline-quote
      (unless (--any (funcall it ,path git-info) treemacs-pre-file-insert-predicates)
-       (concat
-        ,prefix
-        (propertize (file-name-nondirectory ,path)
-                    'button '(t)
-                    'category 'default-button
-                    'help-echo nil
-                    'keymap nil
-                    'face (treemacs--get-node-face ,path ,git-info 'treemacs-directory-face)
-                    :default-face 'treemacs-directory-face
-                    :state 'dir-node-closed
-                    :path ,path
-                    :key ,path
-                    :symlink (file-symlink-p ,path)
-                    :parent ,parent
-                    :depth ,depth))))))
+       (propertize (concat ,prefix (file-name-nondirectory ,path))
+                   'button '(t)
+                   'category 'default-button
+                   'help-echo nil
+                   'keymap nil
+                   'face (treemacs--get-node-face ,path ,git-info 'treemacs-directory-face)
+                   :default-face 'treemacs-directory-face
+                   :state 'dir-node-closed
+                   :path ,path
+                   :key ,path
+                   :symlink (file-symlink-p ,path)
+                   :parent ,parent
+                   :depth ,depth)))))
 
 (define-inline treemacs--create-file-button-strings (path prefix parent depth git-info)
   "Return the text to insert for a file button for PATH.
@@ -207,21 +205,20 @@ GIT-INFO is the git info of the current directory."
   (inline-letevals (path prefix parent depth git-info)
     (inline-quote
      (unless (--any (funcall it ,path git-info) treemacs-pre-file-insert-predicates)
-       (concat
-        ,prefix
-        (treemacs-icon-for-file ,path)
-        (propertize (file-name-nondirectory ,path)
-                    'button '(t)
-                    'category 'default-button
-                    'help-echo nil
-                    'keymap nil
-                    'face (treemacs--get-node-face ,path ,git-info 'treemacs-git-unmodified-face)
-                    :default-face 'treemacs-git-unmodified-face
-                    :state 'file-node-closed
-                    :path ,path
-                    :key ,path
-                    :parent ,parent
-                    :depth ,depth))))))
+       (propertize (concat ,prefix
+                           (treemacs-icon-for-file ,path)
+                           (file-name-nondirectory ,path))
+                   'button '(t)
+                   'category 'default-button
+                   'help-echo nil
+                   'keymap nil
+                   'face (treemacs--get-node-face ,path ,git-info 'treemacs-git-unmodified-face)
+                   :default-face 'treemacs-git-unmodified-face
+                   :state 'file-node-closed
+                   :path ,path
+                   :key ,path
+                   :parent ,parent
+                   :depth ,depth)))))
 
 (cl-defmacro treemacs--button-open (&key button new-state new-icon open-action post-open-action immediate-insert)
   "Building block macro to open a BUTTON.
@@ -375,26 +372,21 @@ set to PARENT."
                           ('deferred
                             (run-with-timer 0.5 nil #'treemacs--apply-deferred-git-state ,parent ,git-future (current-buffer))
                             (or (ht-get treemacs--git-cache ,root) (ht)))
-                          (_ (ht))))
-              (file-strings)
-              (dir-strings))
-         (setq dir-strings
-               (treemacs--create-buttons
-                :nodes dirs
-                :extra-vars ((dir-prefix (concat prefix treemacs-icon-dir-closed)))
-                :depth ,depth
-                :node-name node
-                :node-action (treemacs--create-dir-button-strings node dir-prefix ,parent ,depth git-info)))
-         (setq file-strings
-               (treemacs--create-buttons
-                :nodes files
-                :depth ,depth
-                :node-name node
-                :node-action (treemacs--create-file-button-strings node prefix ,parent ,depth git-info)))
+                          (_ (ht)))))
 
-         (dolist (string dir-strings)
+         (dolist (string (treemacs--create-buttons
+                          :nodes dirs
+                          :extra-vars ((dir-prefix (concat prefix treemacs-icon-dir-closed)))
+                          :depth ,depth
+                          :node-name node
+                          :node-action (treemacs--create-dir-button-strings node dir-prefix ,parent ,depth git-info)))
            (insert string "\n"))
-         (dolist (string file-strings)
+
+         (dolist (string (treemacs--create-buttons
+                          :nodes files
+                          :depth ,depth
+                          :node-name node
+                          :node-action (treemacs--create-file-button-strings node prefix ,parent ,depth git-info)))
            (insert string "\n"))
 
          (save-excursion
@@ -530,10 +522,9 @@ Remove all open dir and tag entries under BTN when RECURSIVE."
   "Insert a new root node for the given PROJECT node.
 
 PROJECT: Project Struct"
-  (insert treemacs-icon-root)
   (treemacs--set-project-position project (point-marker))
   (insert
-   (propertize (treemacs-project->name project)
+   (propertize (concat treemacs-icon-root (treemacs-project->name project))
                'button '(t)
                'category 'default-button
                'face (treemacs--root-face project)

--- a/src/elisp/treemacs-tags.el
+++ b/src/elisp/treemacs-tags.el
@@ -138,17 +138,15 @@ PARENT: Button
 DEPTH: Int"
   (inline-letevals (item prefix parent depth)
     (inline-quote
-     (concat
-      ,prefix
-      (propertize (car ,item)
-                  'button '(t)
-                  'category 'default-button
-                  'face 'treemacs-tags-face
-                  'help-echo nil
-                  :state 'tag-node
-                  :parent ,parent
-                  :depth ,depth
-                  :marker (cdr ,item))))))
+     (propertize (concat ,prefix (car ,item))
+                 'button '(t)
+                 'category 'default-button
+                 'face 'treemacs-tags-face
+                 'help-echo nil
+                 :state 'tag-node
+                 :parent ,parent
+                 :depth ,depth
+                 :marker (cdr ,item)))))
 
 (define-inline treemacs--insert-tag-node (node prefix parent depth)
   "Return the text to insert for a tag NODE.
@@ -161,17 +159,15 @@ PARENT: Button
 DEPTH: Int"
   (inline-letevals (node prefix parent depth)
     (inline-quote
-     (concat
-      ,prefix
-      (propertize (car ,node)
-                  'button '(t)
-                  'category 'default-button
-                  'face 'treemacs-tags-face
-                  'help-echo nil
-                  :state 'tag-node-closed
-                  :parent ,parent
-                  :depth ,depth
-                  :index (cdr ,node))))))
+     (propertize (concat ,prefix (car ,node))
+                 'button '(t)
+                 'category 'default-button
+                 'face 'treemacs-tags-face
+                 'help-echo nil
+                 :state 'tag-node-closed
+                 :parent ,parent
+                 :depth ,depth
+                 :index (cdr ,node)))))
 
 (defun treemacs--expand-file-node (btn &optional recursive)
   "Open tag items for file BTN.

--- a/src/elisp/treemacs-tags.el
+++ b/src/elisp/treemacs-tags.el
@@ -138,7 +138,7 @@ PARENT: Button
 DEPTH: Int"
   (inline-letevals (item prefix parent depth)
     (inline-quote
-     (list
+     (concat
       ,prefix
       (propertize (car ,item)
                   'button '(t)
@@ -161,7 +161,7 @@ PARENT: Button
 DEPTH: Int"
   (inline-letevals (node prefix parent depth)
     (inline-quote
-     (list
+     (concat
       ,prefix
       (propertize (car ,node)
                   'button '(t)

--- a/src/elisp/treemacs-visuals.el
+++ b/src/elisp/treemacs-visuals.el
@@ -151,13 +151,13 @@ Also called as advice after `load-theme', hence the ignored argument."
           (when treemacs-fringe-indicator-mode
             (treemacs--move-fringe-indicator-to-point))
           (-when-let (btn (treemacs-current-button))
-            (let* ((pos (max (point-at-bol) (- (treemacs-button-start btn) 2)))
-                   (img-selected (get-text-property pos 'img-selected)))
+            (-when-let* ((pos (text-property-not-all btn (point-at-eol) 'img-selected nil))
+                         (img-selected (get-text-property pos 'img-selected)))
               (treemacs-with-writable-buffer
                (when (and treemacs--last-highlight
                           (> (point-max) treemacs--last-highlight))
-                 (let* ((last-pos (- (treemacs-button-start treemacs--last-highlight) 2))
-                        (img-unselected (get-text-property last-pos 'img-unselected)))
+                 (-when-let* ((last-pos (text-property-not-all (treemacs-button-start treemacs--last-highlight) (treemacs-button-end treemacs--last-highlight) 'img-unselected nil))
+                              (img-unselected (get-text-property last-pos 'img-unselected)))
                    (put-text-property last-pos (1+ last-pos) 'display img-unselected)))
                (when img-selected
                  (put-text-property pos (1+ pos) 'display img-selected)

--- a/src/elisp/treemacs-workspaces.el
+++ b/src/elisp/treemacs-workspaces.el
@@ -567,7 +567,10 @@ PROJECT, excluding newlines."
     (goto-char (treemacs-project->position project))
     (let* ((start (point-at-bol))
            (next  (treemacs--next-non-child-button (treemacs-project->position project)))
-           (end   (if next (-> next (treemacs-button-start) (previous-button) (treemacs-button-end)) (point-max))))
+           (end   (if next
+                      (- (treemacs-button-start next)
+                         (if treemacs-space-between-root-nodes 1 0))
+                    (point-max))))
       (cons start end))))
 
 (defun treemacs--consolidate-projects ()


### PR DESCRIPTION
This is a rather large change.

- Buttons now include the whitespace and icon at their beginning. This makes it possible to add custom keymaps to the buttons. I have a branch for that, to add custom create/copy/rename/etc. actions for extension buttons. There was also some reason to do that here, but I forget what it was. Maybe it even isn't necessary anymore after all the iterations I made to this.
- Buttons "own" any trailing newlines.
- Trailing newlines are printed unconditionally.
- Motion is constrained to the last project in `treemacs--post-command`

I printed the `buffer-string` after various operations involving variadic extensions, and could not break them this time. The hidden nodes always seem to be on their own lines.

I could not manage to narrow the buffer to the visible part even this way, since that could have meant narrowing empty variadic extension buttons away.

I also didn't manage to make the project separator use a display property for inter-project space, since `hl-line-mode` would paint the whole two-line separator when a project would be hovered.