### PR TITLE
[Rendering] Fix create ingnored file.

### DIFF
--- a/src/elisp/treemacs-filewatch-mode.el
+++ b/src/elisp/treemacs-filewatch-mode.el
@@ -181,7 +181,8 @@ file from caches if it has been deleted instead of waiting for file processing."
             (treemacs-run-in-every-buffer
              (treemacs--on-rename old-name new-name))
             (treemacs--set-refresh-flags (treemacs--nearest-parent-directory old-name) 'deleted old-name)
-            (treemacs--set-refresh-flags (treemacs--nearest-parent-directory new-name) 'created new-name))
+            (when (--none? (funcall it (treemacs--filename new-name) new-name) treemacs-ignored-file-predicates)
+              (treemacs--set-refresh-flags (treemacs--nearest-parent-directory new-name) 'created new-name)))
         (treemacs--set-refresh-flags (treemacs--parent path) event-type path)))))
 
 (define-inline treemacs--do-process-file-events ()


### PR DESCRIPTION
I found some strange renamed events, such as `old-name` is "recentf" and `new-name` is "recentf~".

https://github.com/Alexander-Miller/treemacs/blob/d653a14ae8aea89d166edb825580fde31c8328f1/src/elisp/treemacs-filewatch-mode.el#L178-L185

This will cause ignored file to be displayed.

![image](https://user-images.githubusercontent.com/13600799/66367930-eec30500-e9c8-11e9-9206-cc87225ffc37.png)