### PR TITLE
[Git] Fix syntax error for Python3.* < Python3.6

### DIFF
--- a/src/scripts/treemacs-single-file-git-status.py
+++ b/src/scripts/treemacs-single-file-git-status.py
@@ -62,8 +62,8 @@ def main():
             result_list.append((proc_list[i][0], propagate_state))
             i += 1
 
-    elisp_conses = "".join([f'("{path}" . "{state}")' for path,state in result_list])
-    elisp_alist = f"({elisp_conses})"
+    elisp_conses = "".join(['("{}" . "{}")'.format(path, state) for path,state in result_list])
+    elisp_alist = "({})".format(elisp_conses)
     print(elisp_alist)
 
 def add_git_processes(status_listings, path):


### PR DESCRIPTION
Addresses issue #540 

PEP 498: Formatted string literals were not available until
Python3.6.  Adjusted `treemacs-single-file-git-status.py`
to use generally available interpolation formatting.