### PR TITLE
[Git] Fix deadlock in git status python subprocesses

### DIFF
--- a/src/scripts/treemacs-single-file-git-status.py
+++ b/src/scripts/treemacs-single-file-git-status.py
@@ -42,15 +42,15 @@ def main():
     propagate_state = None
     while i < l:
         path, ignore_proc, tracked_proc, changed_proc = proc_list[i]
-        if ignore_proc.wait() == 0:
+        if ignore_proc.communicate() and ignore_proc.returncode == 0:
             propagate_state = "!"
             result_list.append((path, propagate_state))
             break
-        elif tracked_proc.wait() == 1:
+        elif tracked_proc.communicate() and tracked_proc.returncode == 1:
             propagate_state = "?"
             result_list.append((path, propagate_state))
             break
-        elif changed_proc.wait() == 1:
+        elif changed_proc.communicate() and changed_proc.returncode == 1:
             result_list.append((path, "M"))
         else:
             result_list.append((path, "0"))

--- a/src/scripts/treemacs-single-file-git-status.py
+++ b/src/scripts/treemacs-single-file-git-status.py
@@ -42,15 +42,15 @@ def main():
     propagate_state = None
     while i < l:
         path, ignore_proc, tracked_proc, changed_proc = proc_list[i]
-        if ignore_proc.communicate() and ignore_proc.returncode == 0:
+        if ignore_proc.wait() == 0:
             propagate_state = "!"
             result_list.append((path, propagate_state))
             break
-        elif tracked_proc.communicate() and tracked_proc.returncode == 1:
+        elif tracked_proc.wait() == 1:
             propagate_state = "?"
             result_list.append((path, propagate_state))
             break
-        elif changed_proc.communicate() and changed_proc.returncode == 1:
+        elif changed_proc.wait() == 1:
             result_list.append((path, "M"))
         else:
             result_list.append((path, "0"))
@@ -67,9 +67,9 @@ def main():
     print(elisp_alist)
 
 def add_git_processes(status_listings, path):
-    ignored_proc = Popen(IS_IGNORED_CMD + path, shell=True, stdout=PIPE, stderr=DEVNULL)
-    tracked_proc = Popen(IS_TRACKED_CMD + path, shell=True, stdout=PIPE, stderr=DEVNULL)
-    changed_proc = Popen(IS_CHANGED_CMD + path, shell=True, stdout=PIPE, stderr=DEVNULL)
+    ignored_proc = Popen(IS_IGNORED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL)
+    tracked_proc = Popen(IS_TRACKED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL)
+    changed_proc = Popen(IS_CHANGED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL)
 
     status_listings.append((path, ignored_proc, tracked_proc, changed_proc))
 


### PR DESCRIPTION
[Git] Addresses issue: https://github.com/Alexander-Miller/treemacs/issues/550

Deadlock can happen when large amounts of data are returned from
git commands inside Popen() with stdout=PIPE.

Relevant reference can be found here:
https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait

Adjusting to ensure that treemacs can handle larger projects that trigger this condition by avoiding the deadlock condition all together.
