### PR TITLE
[Compatibility] update winum regex as scoped buffers were added

### DIFF
--- a/src/elisp/treemacs-compatibility.el
+++ b/src/elisp/treemacs-compatibility.el
@@ -35,7 +35,7 @@
 
 (with-eval-after-load 'winum
   (when (boundp 'winum-ignored-buffers-regexp)
-    (add-to-list 'winum-ignored-buffers-regexp (regexp-quote (format "%sFramebuffer-" treemacs--buffer-name-prefix)))))
+    (add-to-list 'winum-ignored-buffers-regexp (regexp-quote treemacs--buffer-name-prefix))))
 
 (with-eval-after-load 'ace-window
   (when (boundp 'aw-ignored-buffers)


### PR DESCRIPTION
`Treemacs-Scoped-Buffer`s were added, so it is better to ignore any buffer containing name prefix