### PR TITLE
Add support for custom mode line format

### DIFF
--- a/README.org
+++ b/README.org
@@ -410,6 +410,7 @@ setting. Setting them all yourself is not necessary, they are only listed here t
             treemacs-space-between-root-nodes      t
             treemacs-tag-follow-cleanup            t
             treemacs-tag-follow-delay              1.5
+            treemacs-user-mode-line-format         nil
             treemacs-width                         35)
 
       ;; The default width and height of the icons is 22 pixels. If you are
@@ -513,6 +514,7 @@ Treemacs offers the following configuration options (~describe-variable~ will us
 | treemacs-file-extension-regex          | Text after last period                           | Determines how treemacs detects a file extension. Can be set to use text after first or last period.                                                                                                                                 |
 | treemacs-directory-name-transformer    | identity                                         | Transformer function that is applied to directory names before rendering for any sort of cosmetic effect.                                                                                                                            |
 | treemacs-file-name-transformer         | identity                                         | Transformer function that is applied to file names before rendering for any sort of cosmetic effect.                                                                                                                                 |
+| treemacs-user-mode-line-format nil     | nil                                              | When non-nil treemacs will use it as a mode line format (otherwise format provided by ~spaceline~, ~moody-mode-line~ and ~doom-modeline~ will be used or, finally, "Treemacs" text will be displayed)                                    |
 
 ** Faces
 Treemacs defines and uses the following faces:

--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -874,6 +874,17 @@ ast the *first* period of the file name
   :type `(choice (const :tag "Text after first period" ,treemacs-first-period-regex-value)
                  (const :tag "Text after last period" ,treemacs-last-period-regex-value)))
 
+(defcustom treemacs-user-mode-line-format nil
+  "Custom mode line format to be used in `treemacs-mode'.
+
+If nil treemacs will look for default value provided by `spaceline', `moody'
+or `doom-modeline' in that order. Finally, if none of these packages is
+available \"Treemacs\" text will be displayed.
+
+For more specific information about formatting mode line check `mode-line-format'."
+  :type 'sexp
+  :group 'treemacs)
+
 (provide 'treemacs-customization)
 
 ;;; treemacs-customization.el ends here

--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -353,7 +353,9 @@ to it will instead show a blank."
 (defun treemacs--setup-mode-line ()
   "Create either a simple modeline, or integrate into spaceline."
   (setq mode-line-format
-        (cond ((fboundp 'spaceline-install)
+        (cond (treemacs-user-mode-line-format
+               treemacs-user-mode-line-format)
+              ((fboundp 'spaceline-install)
                (spaceline-install
                 "treemacs" '((workspace-number
                               :face highlight-face)


### PR DESCRIPTION
Allows user to specify their `treemacs` mode-line format through setting variable `treemacs--user-mode-line-format` to desired value without overriding `treemacs--setup-mode-line` function.