### PR TITLE
Fix minor typo in user mode line format variable

### DIFF
--- a/README.org
+++ b/README.org
@@ -514,7 +514,7 @@ Treemacs offers the following configuration options (~describe-variable~ will us
 | treemacs-file-extension-regex          | Text after last period                           | Determines how treemacs detects a file extension. Can be set to use text after first or last period.                                                                                                                                 |
 | treemacs-directory-name-transformer    | identity                                         | Transformer function that is applied to directory names before rendering for any sort of cosmetic effect.                                                                                                                            |
 | treemacs-file-name-transformer         | identity                                         | Transformer function that is applied to file names before rendering for any sort of cosmetic effect.                                                                                                                                 |
-| treemacs-user-mode-line-format nil     | nil                                              | When non-nil treemacs will use it as a mode line format (otherwise format provided by ~spaceline~, ~moody-mode-line~ and ~doom-modeline~ will be used or, finally, "Treemacs" text will be displayed)                                    |
+| treemacs-user-mode-line-format         | nil                                              | When non-nil treemacs will use it as a mode line format (otherwise format provided by ~spaceline~, ~moody-mode-line~ and ~doom-modeline~ will be used or, finally, "Treemacs" text will be displayed)                                    |
 
 ** Faces
 Treemacs defines and uses the following faces:


### PR DESCRIPTION
Second take of the PR with commit under ```[Docs]```.