### PR TITLE
[Header Line] Hide global header line if there is one

### DIFF
--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -439,8 +439,10 @@ Will simply return `treemacs--eldoc-msg'."
   ;; invoke the movement of the fringe overlay that would otherwise be nil
   (when treemacs-fringe-indicator-mode
     (treemacs--enable-fringe-indicator))
-  (when treemacs-user-header-line-format
-    (setf header-line-format treemacs-user-header-line-format))
+  (if treemacs-user-header-line-format
+      (setf header-line-format treemacs-user-header-line-format)
+    (when header-line-format
+      (setf header-line-format nil)))
   (hl-line-mode t)
 
   ;; needs to run manually the first time treemacs is loaded, since the hook is only added *after*


### PR DESCRIPTION
Make sure buffer-local `header-line-format` is set to `nil` when
`treemacs-user-header-line-format` is set to `nil`. This change is
useful for those who use a header line instead of a mode line. When no
custom header is set for treemacs, it now does not show the global
one.

Before the change:

![Screen Shot 2020-05-16 at 10 30 46 PM](https://user-images.githubusercontent.com/292028/82117592-1ed74f80-97c5-11ea-96eb-35624ba39556.png)

After the change:

![Screen Shot 2020-05-16 at 10 31 41 PM](https://user-images.githubusercontent.com/292028/82117600-2991e480-97c5-11ea-83cd-399aa4090da8.png)
