### PR TITLE
Fix fringe customization

### DIFF
--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -524,7 +524,12 @@ missing project will not appear in the project list next time Emacs is started."
       (define-fringe-bitmap 'treemacs--fringe-indicator-bitmap-default (make-vector 200 #b00000111))
     'vertical-bar)
   "The fringe bitmap used by the fringe-indicator minor mode."
-  :type 'symbol
+  :type (append '(choice)
+                ;; :type is evaluated before the call to define-fringe-bitmap
+                ;; so 'treemacs--fringe-indicator-bitmap-default is not yet in
+                ;; fringe-bitmaps
+                '((const treemacs--fringe-indicator-bitmap-default))
+                (mapcar (lambda (sym) `(const ,sym)) fringe-bitmaps))
   :group 'treemacs)
 
 (defcustom treemacs-show-cursor nil

--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -521,39 +521,10 @@ missing project will not appear in the project list next time Emacs is started."
 
 (defcustom treemacs--fringe-indicator-bitmap
   (if (fboundp 'define-fringe-bitmap)
-      (define-fringe-bitmap 'treemacs--fringe-indicator-bitmap
-        (vector #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111
-                #b00000111))
+      (define-fringe-bitmap 'treemacs--fringe-indicator-bitmap-default (make-vector 200 #b00000111))
     'vertical-bar)
   "The fringe bitmap used by the fringe-indicator minor mode."
-  :type 'fringe-bitmap
-  :options (if (fboundp 'fringe-bitmaps)
-               (cons 'treemacs--fringe-indicator-bitmap fringe-bitmaps)
-             nil)
+  :type 'symbol
   :group 'treemacs)
 
 (defcustom treemacs-show-cursor nil

--- a/src/elisp/treemacs-fringe-indicator.el
+++ b/src/elisp/treemacs-fringe-indicator.el
@@ -44,8 +44,8 @@
     (setq-local treemacs--fringe-indicator-overlay
                 (-let [ov (make-overlay 1 1 (current-buffer))]
                   (overlay-put ov 'before-string
-                               (propertize " " 'display '(left-fringe
-                                                          treemacs--fringe-indicator-bitmap
+                               (propertize " " 'display `(left-fringe
+                                                          ,treemacs--fringe-indicator-bitmap
                                                           treemacs-fringe-indicator-face)))
                   ov))
     (treemacs--move-fringe-indicator-to-point)))


### PR DESCRIPTION
- Fix display property of the fringe overlay 
  This worked because the defcustom and the bitmap were on the same
  symbol.
  The fringe property is expecting the symbol of the bitmap, so this
  ignored the value of the defcustom.

- Make the default fringe bitmap bigger and fix type of the defcustom
  The default bitmap didn't fill the whole line in my config
  