### PR TITLE
fix: treemacs-perspective misspelling as treemacs-persective

### DIFF
--- a/README.org
+++ b/README.org
@@ -473,7 +473,7 @@ setting. Setting them all yourself is not necessary, they are only listed here t
     :after treemacs magit
     :ensure t)
 
-  (use-package treemacs-persp ;;treemacs-persective if you use perspective.el vs. persp-mode
+  (use-package treemacs-persp ;;treemacs-perspective if you use perspective.el vs. persp-mode
     :after treemacs persp-mode ;;or perspective vs. persp-mode
     :ensure t
     :config (treemacs-set-scope-type 'Perspectives))


### PR DESCRIPTION
treemacs-perspective was spelt wrong so when I copied the spelling from the
README file and pasted it into my configuration to install, I got an error
stating that no package exists in Melpa by that name. I corrected this just
in-case someone else does the same thing in the future, then there won't be any
errors.