### PR TITLE
Fix unknown change event: `magit-refresh`

### DIFF
--- a/src/elisp/treemacs-filewatch-mode.el
+++ b/src/elisp/treemacs-filewatch-mode.el
@@ -62,6 +62,14 @@ buffers watching that path, its cdr is the watch descriptor.")
   "Timer that will run a refresh after `treemacs-file-event-delay' ms.
 Stored here to allow it to be cancelled by a manual refresh.")
 
+(define-inline treemacs--start-filewatch-timer ()
+  "Start the filewatch timer if it is not already running."
+  (inline-quote
+   (unless treemacs--refresh-timer
+     (setf treemacs--refresh-timer
+           (run-with-timer (/ treemacs-file-event-delay 1000) nil
+                           #'treemacs--process-file-events)))))
+
 (define-inline treemacs--cancel-refresh-timer ()
   "Cancel a the running refresh timer if it is active."
   (inline-quote
@@ -170,10 +178,8 @@ Also start the refresh timer if it's not started already."
               ('changed
                (when (eq ,type 'deleted)
                  (setf (cdr current-flag) 'deleted))))))
-        (unless treemacs--refresh-timer
-          (setf treemacs--refresh-timer
-                (run-with-timer (/ treemacs-file-event-delay 1000) nil
-                                #'treemacs--process-file-events))))))))
+        (treemacs--start-filewatch-timer))))))
+
 
 (defun treemacs--filewatch-callback (event)
   "Add EVENT to the list of file change events.

--- a/src/elisp/treemacs-rendering.el
+++ b/src/elisp/treemacs-rendering.el
@@ -1020,6 +1020,11 @@ parents' git status can be updated."
                  (treemacs-update-single-file-git-state path)))
               ('created
                (treemacs-do-insert-single-node path (treemacs-dom-node->key node)))
+              ('force-refresh
+               (setf recurse nil)
+               (if (null (treemacs-dom-node->parent node))
+                   (treemacs-project->refresh! project)
+                 (treemacs--refresh-dir (treemacs-dom-node->key node) project)))
               (_
                ;; Renaming is handled as a combination of delete+create, so
                ;; this case should never be taken

--- a/src/extra/treemacs-magit.el
+++ b/src/extra/treemacs-magit.el
@@ -69,15 +69,11 @@ In order for the update to fully run several conditions must be met:
 Without the parsing ability of extended git-mode this update uses
 filewatch-mode's mechanics to update the entire project."
   (treemacs-run-in-every-buffer
-   (when-let* ((project (treemacs--find-project-for-path magit-root)))
-     (let* ((project-root (treemacs-project->path project))
-            (dom-node (treemacs-find-in-dom project-root)))
-       (when (and dom-node
-                  (null (treemacs-dom-node->refresh-flag dom-node)))
-         ;; adding a number of change events is the easiest way to cause a full directory
-         ;; refresh without touching treemacs proper
-         (dotimes (_ 8)
-           (treemacs--set-refresh-flags project-root 'magit-refresh project-root)))))))
+   (when-let* ((project (treemacs--find-project-for-path magit-root))
+               (dom-node (treemacs-find-in-dom (treemacs-project->path project))))
+     (push (cons (treemacs-project->path project) 'force-refresh)
+           (treemacs-dom-node->refresh-flag dom-node))
+     (treemacs--start-filewatch-timer))))
 
 (defun treemacs-magit--extended-git-mode-update (magit-root)
   "Update the project at the given MAGIT-ROOT.


### PR DESCRIPTION
`treemacs-magit--schedule-refresh` calls `treemacs--set-refresh-flags` with
`magit-refresh`, which, being a change event not explicitly handled, causes the
above warning. The only side effect of the call to `treemacs--set-refresh-flag`
is to cause the `treemacs` project to be refreshed, though, so call
`treemacs-project->refresh` directly, fixing the message.


----

#