### PR TITLE
Fix Perspective compatibility

### DIFF
--- a/src/elisp/treemacs-bookmarks.el
+++ b/src/elisp/treemacs-bookmarks.el
@@ -196,7 +196,8 @@ treemacs node is pointing to a valid buffer position."
       (-let [name (treemacs--read-string "Bookmark name: ")]
         (bookmark-store name `((filename . ,(treemacs-button-get current-btn :path))) nil)))
      ('tag-node
-      (-let [(tag-buffer . tag-pos) (treemacs--extract-position (treemacs-button-get current-btn :marker))]
+      (-let [(tag-buffer . tag-pos)
+             (treemacs--extract-position (treemacs-button-get current-btn :marker) nil)]
         (if (buffer-live-p tag-buffer)
             (bookmark-store
              (treemacs--read-string "Bookmark name: ")

--- a/src/elisp/treemacs-mouse-interface.el
+++ b/src/elisp/treemacs-mouse-interface.el
@@ -179,8 +179,8 @@ and ignore any prefix argument."
           (let ((index (treemacs--get-imenu-index file)))
             (dolist (path-item path)
               (setq index (cdr (assoc path-item index))))
-            (-let [(buf . pos) (treemacs--extract-position
-                                (cdr (--first (equal (car it) tag) index)))]
+            (-let [(buf . pos)
+                   (treemacs--extract-position (cdr (--first (equal (car it) tag) index)) path)]
               ;; some imenu implementations, like markdown, will only provide
               ;; a raw buffer position (an int) to move to
 	      (list (or buf (get-file-buffer file)) pos))))
@@ -205,7 +205,9 @@ and ignore any prefix argument."
              (marker-position (save-excursion (xref-location-marker (xref-item-location item))))))
     (-let [(tag-buf . tag-pos)
            (treemacs-with-button-buffer btn
-             (-> btn (treemacs-button-get :marker) (treemacs--extract-position)))]
+             (let ((marker (treemacs-button-get :marker btn))
+                   (path (treemacs-button-get :path btn)))
+               (treemacs--extract-position marker path)))]
       (if tag-buf
           (list tag-buf tag-pos)
         (pcase treemacs-goto-tag-strategy

--- a/src/elisp/treemacs-tags.el
+++ b/src/elisp/treemacs-tags.el
@@ -370,7 +370,10 @@ The position can be stored in the following ways:
   element's 'org-imenu-marker text property.
 * ITEM is a cons: special case for imenu elements of an `pdfview-mode' buffer.
   In this case no position is stored directly, navigation to the tag must happen
-  via callback"
+  via callback
+
+FILE is the path the tag is in, so far it is only relevant for `pdfview-mode'
+tags."
   (declare (side-effect-free t))
   (pcase (type-of item)
     ('marker

--- a/src/extra/treemacs-perspective.el
+++ b/src/extra/treemacs-perspective.el
@@ -53,16 +53,20 @@ Will return \"No Perspective\" if no perspective is active."
       "No Perspective"
     (format "Perspective %s" (persp-name perspective))))
 
+(defun treemacs-perspective--on-scope-kill ()
+  "Cleanup hook to run when a perspective is killed."
+  (treemacs--on-scope-kill (persp-current-name)))
+
 (cl-defmethod treemacs-scope->setup ((_ (subclass treemacs-perspective-scope)))
   "Perspective-scope setup."
   (add-hook 'persp-switch-hook #'treemacs-perspective--on-perspective-switch)
-  (add-hook 'persp-killed-hook #'treemacs--on-scope-kill)
+  (add-hook 'persp-killed-hook #'treemacs-perspective--on-scope-kill)
   (treemacs-perspective--ensure-workspace-exists))
 
 (cl-defmethod treemacs-scope->cleanup ((_ (subclass treemacs-perspective-scope)))
   "Perspective-scope tear-down."
   (remove-hook 'persp-switch-hook #'treemacs-perspective--on-perspective-switch)
-  (remove-hook 'persp-killed-hook #'treemacs--on-scope-kill))
+  (remove-hook 'persp-killed-hook #'treemacs-perspective--on-scope-kill))
 
 (defun treemacs-perspective--on-perspective-switch (&rest _)
   "Hook running after the perspective was switched.


### PR DESCRIPTION
Here from https://github.com/nex3/perspective-el/issues/144

The treemacs-perspective wrapper calls `persp-killed-hook` incorrectly. This hook in Perspective does not have a "scope" or "name" parameter. The perspective being killed is the current perspective, and the usual introspection helpers for determining the current perspective are available.

Thanks to @Randy1Burrell for reporting the bug and testing the patch.