### PR TITLE
[Doc] Update examples to adhere to use-package semantics

### DIFF
--- a/README.org
+++ b/README.org
@@ -457,24 +457,24 @@ setting. Setting them all yourself is not necessary, they are only listed here t
           ("C-x t M-t" . treemacs-find-tag)))
 
   (use-package treemacs-evil
-    :after treemacs evil
+    :after (treemacs evil)
     :ensure t)
 
   (use-package treemacs-projectile
-    :after treemacs projectile
+    :after (treemacs projectile)
     :ensure t)
 
   (use-package treemacs-icons-dired
-    :after treemacs dired
+    :after (treemacs dired)
     :ensure t
     :config (treemacs-icons-dired-mode))
 
   (use-package treemacs-magit
-    :after treemacs magit
+    :after (treemacs magit)
     :ensure t)
 
   (use-package treemacs-persp ;;treemacs-perspective if you use perspective.el vs. persp-mode
-    :after treemacs persp-mode ;;or perspective vs. persp-mode
+    :after (treemacs persp-mode) ;;or perspective vs. persp-mode
     :ensure t
     :config (treemacs-set-scope-type 'Perspectives))
 #+END_SRC


### PR DESCRIPTION
In the `use-package` documentation it suggested that when using the `:after`
keyword with multiple packages, they should be in a list. This have become
apparent to me after working with `treemacs` for sometime and getting certain
errors. I updated the example in the doc, just in-case other users copy the
examples and try to use it directly without modification, then it will just work
without problems.

If applied, this commit will:

    - Update the example that uses use-package :after key word with multiple
      packages to be a list.