### PR TITLE
Fix reading treemacs-persist-file containing multibyte symbols

### DIFF
--- a/src/elisp/treemacs-persistence.el
+++ b/src/elisp/treemacs-persistence.el
@@ -201,7 +201,7 @@ ITER: Treemacs-Iter Struct"
 Will read all lines, except those that start with # or contain only whitespace."
   (-some->> (or txt (when (file-exists-p treemacs-persist-file)
                       (with-temp-buffer
-                        (insert-file-contents-literally treemacs-persist-file)
+                        (insert-file-contents treemacs-persist-file)
                         (buffer-string))))
             (s-trim)
             (s-lines)


### PR DESCRIPTION
I found one bug. If I use multibyte symbols in workspace name or path it renders like that
![treemacs_bug](https://user-images.githubusercontent.com/3434678/109176609-0a82a300-7798-11eb-99db-a206799e63af.png)
The reason of such behavior in using `insert-file-contents-literally` which doesn't decodes text from file.