### PR TITLE
Fix treemacs--file-name-handler-alist for TRAMP

### DIFF
--- a/src/elisp/treemacs-compatibility.el
+++ b/src/elisp/treemacs-compatibility.el
@@ -39,7 +39,8 @@
 (with-eval-after-load 'tramp
   (setf treemacs--file-name-handler-alist
         (with-no-warnings
-          (cons tramp-file-name-regexp #'tramp-file-name-handler))))
+          (list
+           (cons tramp-file-name-regexp #'tramp-file-name-handler)))))
 
 (with-eval-after-load 'recentf
   (with-no-warnings


### PR DESCRIPTION
When 6c431174dd9 introduced treemacs--file-name-handler-alist, it
mistakenly used the wrong format for alists. This broke TRAMP
integration, because the `file-name-handler-alist` was no longer a valid
alist. Fortunately, this is a trivial fix.