### PR TITLE
Populate bookmark-alist from default file

### DIFF
--- a/src/elisp/treemacs-bookmarks.el
+++ b/src/elisp/treemacs-bookmarks.el
@@ -47,6 +47,7 @@ fashion to `treemacs-find-file'.
 With a prefix argument ARG treemacs will also open the bookmarked location."
   (interactive "P")
   (treemacs-block
+   (bookmark-maybe-load-default-file)
    (-let [bookmarks
           (cl-loop
            for b in bookmark-alist


### PR DESCRIPTION
On startup `bookmark-alist` is always empty, unless it's populated somewhere else, hence, calling `treemacs-bookmark` results in "Didn't find any bookmarks" error, even if bookmarks do exist. Made this quick fix that populates `bookmark-alist` inside `treemacs-bookmark` call, if needed