### PR TITLE
Make library commentaries comply more with the conventions.

### DIFF
--- a/src/elisp/treemacs-async.el
+++ b/src/elisp/treemacs-async.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Code for dealing with asynchronous processes.
+
+;; Code for dealing with asynchronous processes.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-bookmarks.el
+++ b/src/elisp/treemacs-bookmarks.el
@@ -16,8 +16,10 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Integrates treemacs with bookmark.el.
-;;; NOTE: This module is lazy-loaded.
+
+;; Integrates treemacs with bookmark.el.
+
+;; NOTE: This module is lazy-loaded.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-compatibility.el
+++ b/src/elisp/treemacs-compatibility.el
@@ -16,8 +16,9 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Simple bits of code to make treemacs compatible with other packages
-;;; that aren't worth the effort of being turned into their own package.
+
+;; Simple bits of code to make treemacs compatible with other packages
+;; that aren't worth the effort of being turned into their own package.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; General implementation details.
+
+;; General implementation details.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Customize interface definitions.
+
+;; Customize interface definitions.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-diagnostics.el
+++ b/src/elisp/treemacs-diagnostics.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; WIP implementation of diagnostics display.
+
+;; WIP implementation of diagnostics display.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-dom.el
+++ b/src/elisp/treemacs-dom.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; Basically this: https://github.com/Alexander-Miller/treemacs/issues/143
+
+;; Basically this: https://github.com/Alexander-Miller/treemacs/issues/143.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-extensions.el
+++ b/src/elisp/treemacs-extensions.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; API required for writing extensions for/with treemacs.
+
+;; API required for writing extensions for/with treemacs.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-faces.el
+++ b/src/elisp/treemacs-faces.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Treemacs faces.
+
+;; Treemacs faces.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-filewatch-mode.el
+++ b/src/elisp/treemacs-filewatch-mode.el
@@ -16,10 +16,14 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; File event watch and reaction implementation.
-;;; Open directories are put under watch and file changes event collected even if filewatch-mode
-;;; is disabled.  This allows to remove deleted files from all the caches they are in.  Activating
-;;; filewatch-mode will therefore only enable automatic refresh of treemacs buffers.
+
+;; File event watch and reaction implementation.
+
+;; Open directories are put under watch and file changes event
+;; collected even if filewatch-mode is disabled.  This allows to
+;; remove deleted files from all the caches they are in.  Activating
+;; filewatch-mode will therefore only enable automatic refresh of
+;; treemacs buffers.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-follow-mode.el
+++ b/src/elisp/treemacs-follow-mode.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Follow mode definition.
+
+;; Follow mode definition.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-fringe-indicator.el
+++ b/src/elisp/treemacs-fringe-indicator.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Handling of visuals in general and icons in particular.
+
+;; Handling of visuals in general and icons in particular.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-header-line.el
+++ b/src/elisp/treemacs-header-line.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Variations of header-line-format treemacs can use.
+
+;; Variations of header-line-format treemacs can use.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-hydras.el
+++ b/src/elisp/treemacs-hydras.el
@@ -16,8 +16,10 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Definition for the Helpful Hydras.
-;;; NOTE: This module is lazy-loaded.
+
+;; Definition for the Helpful Hydras.
+
+;; NOTE: This module is lazy-loaded.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-icons.el
+++ b/src/elisp/treemacs-icons.el
@@ -16,8 +16,10 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Most of everything related to icons is handled here.  Specifically the
-;;; definition, instantiation, customization, resizing and resetting of icons.
+
+;; Most of everything related to icons is handled here.  Specifically
+;; the definition, instantiation, customization, resizing and
+;; resetting of icons.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-interface.el
+++ b/src/elisp/treemacs-interface.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Not autoloaded, but user-facing functions.
+
+;; Not autoloaded, but user-facing functions.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-logging.el
+++ b/src/elisp/treemacs-logging.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Implementation for logging messages.
+
+;; Implementation for logging messages.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-macros.el
+++ b/src/elisp/treemacs-macros.el
@@ -16,9 +16,10 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; General purpose macros, and those used in, but defined outside of
-;;; treemacs-core-utils.el are put here, to prevent using them before their
-;;; definition, hopefully preventing issues like #97.
+
+;; General purpose macros, and those used in, but defined outside of
+;; treemacs-core-utils.el are put here, to prevent using them before
+;; their definition, hopefully preventing issues like #97.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -1,4 +1,4 @@
-;;; treemacs.el --- A tree style file viewer package -*- lexical-binding: t -*-
+;;; treemacs-mode.el --- A tree style file viewer package -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2021 Alexander Miller
 
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Major mode definition.
+
+;; Major mode definition.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-mouse-interface.el
+++ b/src/elisp/treemacs-mouse-interface.el
@@ -16,8 +16,10 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Functions relating to using the mouse in treemacs.
-;;; NOTE: This module is lazy-loaded.
+
+;; Functions relating to using the mouse in treemacs.
+
+;; NOTE: This module is lazy-loaded.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-persistence.el
+++ b/src/elisp/treemacs-persistence.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Persistence of treemacs' workspaces into an org-mode compatible file.
+
+;; Persistence of treemacs' workspaces into an org-mode compatible file.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-rendering.el
+++ b/src/elisp/treemacs-rendering.el
@@ -16,9 +16,10 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Code in this file is considered performance critical.
-;;; The usual restrictions w.r.t quality, readability and maintainability are
-;;; lifted here.
+
+;; Code in this file is considered performance critical.  The usual
+;; restrictions w.r.t quality, readability and maintainability are
+;; lifted here.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-scope.el
+++ b/src/elisp/treemacs-scope.el
@@ -16,13 +16,16 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Module that handles uniquely associating treemacs buffers with a certain scope,
-;;; like the selected frame, or (to be implemented later) the active eyebrowse or
-;;; persp desktop.
-;;; This is implemented using a (somewhat) OOP style with eieio and static functions,
-;;; where each scope type is expected to know how to query the current scope (e.g. the
-;;; selected frame) and how to set up and tear down itself (e.g. deleting a frames
-;;; associated buffer when the frame is deleted)
+
+;; Module that handles uniquely associating treemacs buffers with a
+;; certain scope, like the selected frame, or (to be implemented
+;; later) the active eyebrowse or persp desktop.
+
+;; This is implemented using a (somewhat) OOP style with eieio and
+;; static functions, where each scope type is expected to know how to
+;; query the current scope (e.g. the selected frame) and how to set up
+;; and tear down itself (e.g. deleting a frames associated buffer when
+;; the frame is deleted)
 
 ;;; Code:
 

--- a/src/elisp/treemacs-tag-follow-mode.el
+++ b/src/elisp/treemacs-tag-follow-mode.el
@@ -16,6 +16,7 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
+
 ;; Minor mode to follow the tag at point in the treemacs view on an idle timer
 ;; Finding the current tag is a fairly involved process:
 ;; * Grab current buffer's imenu output
@@ -26,7 +27,8 @@
 ;; * Find the last tag whose position begins before point
 ;; * Jump to that tag path
 ;; * No jump when there's no buffer file, or no imenu, or buffer file is not seen in treemacs etc.
-;;; NOTE: This module is lazy-loaded.
+
+;; NOTE: This module is lazy-loaded.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-tags.el
+++ b/src/elisp/treemacs-tags.el
@@ -16,11 +16,16 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Tags display functionality.
-;;; Need to be very careful here - many of the functions in this module need to be run inside the treemacs buffer, while
-;;; the `treemacs--execute-button-action' macro that runs them will switch windows before doing so.  Heavy use of
-;;; `treemacs-safe-button-get' or `treemacs-with-button-buffer' is necessary.
-;;; NOTE: This module is lazy-loaded.
+
+;; Tags display functionality.
+
+;; Need to be very careful here - many of the functions in this module
+;; need to be run inside the treemacs buffer, while the
+;; `treemacs--execute-button-action' macro that runs them will switch
+;; windows before doing so.  Heavy use of `treemacs-safe-button-get'
+;; or `treemacs-with-button-buffer' is necessary.
+
+;; NOTE: This module is lazy-loaded.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-themes.el
+++ b/src/elisp/treemacs-themes.el
@@ -16,7 +16,9 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Definitions for the theme type, their creation, and, the means to change themes.
+
+;; Definitions for the theme type, their creation, and, the means to
+;; change themes.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-visuals.el
+++ b/src/elisp/treemacs-visuals.el
@@ -16,7 +16,8 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Handling of visuals in general and icons in particular.
+
+;; Handling of visuals in general and icons in particular.
 
 ;;; Code:
 

--- a/src/elisp/treemacs-workspaces.el
+++ b/src/elisp/treemacs-workspaces.el
@@ -16,8 +16,9 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;; Everything about creating, (re)moving, (re)naming and otherwise editing
-;;; projects and workspaces.
+
+;; Everything about creating, (re)moving, (re)naming and otherwise
+;; editing projects and workspaces.
 
 ;;; Code:
 

--- a/src/elisp/treemacs.el
+++ b/src/elisp/treemacs.el
@@ -22,7 +22,7 @@
 
 ;;; Commentary:
 
-;;; A powerful and flexible file tree project explorer.
+;; A powerful and flexible file tree project explorer.
 
 ;;; Code:
 


### PR DESCRIPTION
- Only section headings should begin with three or more semicolons.
  Regular comments as well as all non-heading text in the library
  headers should begin with only two semicolons.

- Once the extra semicolon is removed, it looks quite ugly that there
  is no empty line between the Commentary heading and its body, so add
  that line.

- Use `fill-paragraph` on text in the library commentaries.