### PR TITLE
Add org_archive as extension for org files

### DIFF
--- a/src/elisp/treemacs-icons.el
+++ b/src/elisp/treemacs-icons.el
@@ -436,7 +436,7 @@ Necessary since root icons are not rectangular."
     (treemacs-create-icon :file "vsc/sql.png"       :extensions ("sql"))
     (treemacs-create-icon :file "vsc/toml.png"      :extensions ("toml"))
     (treemacs-create-icon :file "vsc/nim.png"       :extensions ("nim"))
-    (treemacs-create-icon :file "vsc/org.png"       :extensions ("org"))
+    (treemacs-create-icon :file "vsc/org.png"       :extensions ("org" "org_archive"))
     (treemacs-create-icon :file "vsc/perl.png"      :extensions ("pl" "pm" "perl"))
     (treemacs-create-icon :file "vsc/vim.png"       :extensions ("vimrc" "tridactylrc" "vimperatorrc" "ideavimrc" "vrapperrc"))
     (treemacs-create-icon :file "vsc/deps.png"      :extensions ("cask"))

--- a/src/elisp/treemacs-icons.el
+++ b/src/elisp/treemacs-icons.el
@@ -311,7 +311,6 @@ Necessary since root icons are not rectangular."
     (treemacs-create-icon :file "asciidoc.png"      :extensions ("adoc" "asciidoc"))
     (treemacs-create-icon :file "rust.png"          :extensions ("rs"))
     (treemacs-create-icon :file "image.png"         :extensions ("jpg" "jpeg" "bmp" "svg" "png" "xpm" "gif"))
-    (treemacs-create-icon :file "emacs.png"         :extensions ("el" "elc"))
     (treemacs-create-icon :file "clojure.png"       :extensions ("clj" "cljs" "cljc"))
     (treemacs-create-icon :file "ts.png"            :extensions ("ts" "tsx"))
     (treemacs-create-icon :file "vue.png"           :extensions ("vue"))


### PR DESCRIPTION
I have almost as many `foo.org_archive` files as `foo.org` files.
It's configurable but since `.org_archive` is the default I guess
it's ok to have it in there.

I also removed the duplicate elisp icon entry in a different
commit (in case you don't want to add org_archive by default).

Thanks,
  Daniel