### PR TITLE
[Core] Search for python on Windows even with unexpected errors.

### DIFF
--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -39,12 +39,14 @@
                (s-lines)
                (--first
                 (when (file-exists-p it)
-                  (->> (concat (shell-quote-argument it) " --version")
-                       (shell-command-to-string)
-                       (s-trim)
-                       (s-replace "Python " "")
-                       (s-left 1)
-                       (version<= "3")))))
+                  (condition-case _
+                      (->> (concat (shell-quote-argument it) " --version")
+                           (shell-command-to-string)
+                           (s-trim)
+                           (s-replace "Python " "")
+                           (s-left 1)
+                           (version<= "3"))
+                    (error nil)))))
         (error nil)))))
 
 (cl-macrolet


### PR DESCRIPTION
Fixes #844.

Paths to Cygwin binaries utilizing magic cookie symlinks may cause
problems when they show up as a result of running the "where" command.
Keep searching the remaining paths returned from the "where" command
when unexpected errors occur while attempting to obtain the version
from the python binary.