### PR TITLE
Add ability to mark paths for different actions

### DIFF
--- a/src/elisp/treemacs-annotations.el
+++ b/src/elisp/treemacs-annotations.el
@@ -23,8 +23,11 @@
 ;;; Code:
 
 (require 'ht)
+(require 'dash)
+(require 'treemacs-async)
 (require 'treemacs-core-utils)
 (require 'treemacs-workspaces)
+(require 'treemacs-async)
 
 (eval-when-compile
   (require 'treemacs-macros)
@@ -37,15 +40,21 @@
 (defconst treemacs--annotation-store (make-hash-table :size 200 :test 'equal))
 (defconst treemacs--annotation-cache (make-hash-table :size 200 :test 'equal))
 
+;; TODO(2022/02/23): clear on file delete
+
 (cl-defstruct (treemacs-annotation
                (:conc-name treemacs-annotation->)
                (:constructor treemacs-annotation->create!)
                (:copier nil))
-  suffix)
+  suffix
+  suffix-value
+  git-face
+  face
+  face-value)
 
 (define-inline treemacs-get-annotation (path)
   "Get annotation data for the given PATH.
-Will return nil if no annotations exist.
+Will return nil if no annotations exists.
 
 PATH: Node Path"
   (declare (side-effect-free t))
@@ -53,126 +62,283 @@ PATH: Node Path"
     (inline-quote
      (ht-get treemacs--annotation-store ,path))))
 
-(define-inline treemacs--create-new-annotation (path)
-  "Create a new empty annotation for PATH and return it."
-  (declare (side-effect-free t))
-  (inline-letevals (path)
-    (inline-quote
-     (let ((ann (treemacs-annotation->create!)))
-       (ht-set! treemacs--annotation-store ,path ann)
-       ann))))
-
 (define-inline treemacs--remove-annotation-if-empty (ann path)
   "Remove annotation ANN for PATH from the store if it is empty."
   (inline-letevals (ann path)
     (inline-quote
-     (when (null (treemacs-annotation->suffix ,ann))
+     (when (and (null (treemacs-annotation->face ,ann))
+                (null (treemacs-annotation->git-face ,ann))
+                (null (treemacs-annotation->suffix ,ann)))
        (ht-remove! treemacs--annotation-store ,path)))))
 
+;;; Faces
+
+(define-inline treemacs-set-annotation-face (path face source)
+  "Annotate PATH with the given FACE.
+
+Will save the FACE as coming from SOURCE so it can be combined with faces coming
+from other sources.
+
+Source must be a *string* so that multiple face annotations on the same node can
+be sorted to always be applied in the same order, regardless of when they were
+added.
+
+PATH: Node Path
+FACE: Face
+SOURCE: String"
+  (inline-letevals (source path face)
+    (inline-quote
+     (if-let* ((ann (treemacs-get-annotation ,path)))
+         (let* ((face-list (treemacs-annotation->face ann))
+                (old-face (--first (string= ,source (car it)) face-list)))
+           (if old-face
+               (setcdr old-face ,face)
+             (setf (treemacs-annotation->face ann)
+                   (--sort (string< (car it) (car other))
+                           (cons (cons ,source ,face) face-list))))
+           (setf (treemacs-annotation->face-value ann)
+                 (append (mapcar #'cdr (treemacs-annotation->face ann))
+                         (treemacs-annotation->git-face ann))))
+       (ht-set! treemacs--annotation-store ,path
+                (treemacs-annotation->create!
+                 :face (list (cons ,source ,face))
+                 :face-value (list ,face)))))))
+
+(define-inline treemacs-remove-annotation-face (path source)
+  "Remove PATH's face annotation for the given SOURCE.
+
+PATH: Node Path
+SOURCE: String"
+  (inline-letevals (path source)
+    (inline-quote
+     (when-let* ((ann (treemacs-get-annotation ,path)))
+       (let* ((git-face (treemacs-annotation->git-face ann))
+              (old-faces (treemacs-annotation->face ann))
+              (new-faces (--reject-first
+                          (string= ,source (car it))
+                          old-faces)))
+         (if new-faces
+             (setf
+              (treemacs-annotation->face ann)
+              new-faces
+              (treemacs-annotation->face-value ann)
+              (append (mapcar #'cdr new-faces) git-face))
+           (setf
+            (treemacs-annotation->face ann) 'deleted
+            (treemacs-annotation->face-value ann) git-face)))))))
+
+(defun treemacs-clear-annotation-faces (source)
+  "Remove all face annotations of the given SOURCE."
+  (treemacs--maphash treemacs--annotation-store (path ann)
+    (-when-let (face-list (treemacs-annotation->face ann))
+      (setf
+       (treemacs-annotation->face ann)
+       (--reject-first (string= source (car it)) face-list)
+       (treemacs-annotation->face-value ann)
+       (append
+        (mapcar #'cdr (treemacs-annotation->face ann))
+        (treemacs-annotation->git-face ann)))
+      (treemacs--remove-annotation-if-empty ann path))))
+
+;; Suffixes
+
 (define-inline treemacs-set-annotation-suffix (path suffix source)
-  "Add the given SUFFIX to PATH's annotation.
-Will save the SUFFIX as coming from SOURCE so it can be combined with
-other suffixes.
+  "Annotate PATH with the given SUFFIX.
+
+Will save the SUFFIX as coming from SOURCE so it can be combined with suffixes
+coming from other sources.
 
 Source must be a *string* so that multiple suffix annotations on the same node
 can be sorted to always appear in the same order, regardless of when they were
 added.
 
 Treemacs does not prescribe using a specific face for suffix annotations, users
-of this api can propertiue suffixes as they see fit.
+of this api can propertize suffixes as they see fit.
 
 PATH: Node Path
 SUFFIX: String
 SOURCE: String"
   (inline-letevals (source path suffix)
     (inline-quote
-     (let* ((ann (or (treemacs-get-annotation ,path)
-                     (treemacs--create-new-annotation ,path)))
-            (suffix-list (treemacs-annotation->suffix ann))
-            (old-suffix (--first (string= ,source (car it)) suffix-list)))
+     (progn
        (put-text-property 0 (length ,suffix) 'treemacs-suffix-annotation t ,suffix)
-       (if old-suffix
-           (setcdr old-suffix ,suffix)
-         (setf (treemacs-annotation->suffix ann)
-               (--sort (string< (car it) (car other))
-                       (cons (cons ,source ,suffix) suffix-list))))))))
+       (if-let* ((ann (treemacs-get-annotation ,path)))
+           (let* ((suffix-list (treemacs-annotation->suffix ann))
+                  (old-suffix (--first (string= ,source (car it)) suffix-list)))
+             (if old-suffix
+                 (setcdr old-suffix ,suffix)
+               (setf (treemacs-annotation->suffix ann)
+                     (--sort (string< (car it) (car other))
+                             (cons (cons ,source ,suffix) suffix-list))))
+             (setf (treemacs-annotation->suffix-value ann)
+                   (mapconcat #'identity (mapcar #'cdr (treemacs-annotation->suffix ann)) " ")))
+         (ht-set! treemacs--annotation-store ,path
+                  (treemacs-annotation->create!
+                   :suffix (list (cons ,source ,suffix))
+                   :suffix-value ,suffix)))))))
 
 (define-inline treemacs-remove-annotation-suffix (path source)
   "Remove PATH's suffix annotation for the given SOURCE.
+
 PATH: Node Path
 SOURCE: String"
   (inline-letevals (path source)
     (inline-quote
-     (-when-let (ann (treemacs-get-annotation ,path))
-       (let ((suffix-list (treemacs-annotation->suffix ann)))
-         (setf (treemacs-annotation->suffix ann)
-               (--reject-first (string= ,source (car it)) suffix-list)))
-       (treemacs--remove-annotation-if-empty ann ,path)))))
+     (when-let* ((ann (treemacs-get-annotation ,path)))
+       (let* ((old-suffixes (treemacs-annotation->suffix ann))
+              (new-suffixes (--reject-first
+                             (string= ,source (car it))
+                             old-suffixes)))
+         (if new-suffixes
+             (setf
+              (treemacs-annotation->suffix ann)
+              new-suffixes
+              (treemacs-annotation->suffix-value ann)
+              (mapconcat #'identity (mapcar #'cdr (treemacs-annotation->suffix ann)) " "))
+           (setf
+            (treemacs-annotation->suffix ann) 'deleted
+            (treemacs-annotation->suffix-value ann) nil)))))))
 
 (defun treemacs-clear-annotation-suffixes (source)
   "Remove all suffix annotations of the given SOURCE."
-    (treemacs--maphash treemacs--annotation-store (path ann)
-      (let ((suffix-list (treemacs-annotation->suffix ann)))
-        (setf (treemacs-annotation->suffix ann)
-              (--reject-first (string= source (car it)) suffix-list))
-        (treemacs--remove-annotation-if-empty ann path))))
+  (treemacs--maphash treemacs--annotation-store (path ann)
+    (-when-let (suffix-list (treemacs-annotation->suffix ann))
+      (setf
+       (treemacs-annotation->suffix ann)
+       (--reject-first (string= source (car it)) suffix-list)
+       (treemacs-annotation->suffix-value ann)
+       (mapconcat #'identity (mapcar #'cdr (treemacs-annotation->suffix ann)) " "))
+      (treemacs--remove-annotation-if-empty ann path))))
 
-;; TODO(2021/08/18): change annotation application such that only a single
-;; timer is needed even if multiple levels have been expanded
-(defun treemacs--apply-annotations-deferred (btn)
-  "Deferred application for annotations for BTN.
+(defun treemacs--apply-annotations-deferred (btn path buffer git-future)
+  "Deferred application for annotations for BTN and PATH.
 
 Runs on a timer after BTN was expanded and will apply annotations for all of
-BTN's *immediate* children."
-  (-let [buffer (marker-buffer btn)alue]
-    (when (buffer-live-p buffer)
-      (with-current-buffer buffer
-        (save-excursion
-          (treemacs-with-writable-buffer
-           (let* ((btn (treemacs-find-node (treemacs-button-get btn :path)))
-                  (depth (1+ (treemacs-button-get btn :depth))))
-             ;; the depth check ensures that we only iterate over the nodes that
-             ;; are below parent-btn and stop when we've moved on to nodes that
-             ;; are above or belong to the next project
-             (while (and (setq btn (next-button btn))
-                         (>= (treemacs-button-get btn :depth) depth))
-               (when (= depth (treemacs-button-get btn :depth))
-                 (treemacs--do-apply-annotation btn))))))))))
+BTN's *immediate* children.
 
-(define-inline treemacs--do-apply-annotation (btn)
-  "Apply a single BTN's annotations."
-  (inline-letevals (btn)
-    (inline-quote
-     (-when-let (ann (treemacs-get-annotation (treemacs-button-get ,btn :path)))
-       (let ((suffix (treemacs--get-annotation-suffix-string ann)))
-         (goto-char ,btn)
-         (goto-char (or (next-single-property-change
-                         ,btn
-                         'treemacs-suffix-annotation
-                         (current-buffer)
-                         (point-at-eol))
-                        (treemacs-button-end ,btn)))
-         (delete-region (point) (point-at-eol))
-         (when suffix (insert suffix)))))))
+Change will happen in BUFFER, given that it is alive.
 
-(define-inline treemacs--get-annotation-suffix-string (ann)
-  "Get the complete, concatenated suffix string from ANN."
-  (declare (side-effect-free t))
-  (inline-letevals (ann)
-    (inline-quote
-     (-when-let (suffix-list (treemacs-annotation->suffix ,ann))
-       (mapconcat #'cdr suffix-list "")))))
+GIT-FUTURE is only awaited when `deferred' git-mode is used.
 
-(defun treemacs-apply-annotations-in-buffer (buffer)
-  "Apply annotations for all nodes in the given BUFFER."
+BTN: Button
+PATH: Node Path
+BUFFER: Buffer
+GIT-FUTURE: Pfuture"
+  (when (eq 'deferred treemacs--git-mode)
+    (ht-set! treemacs--git-cache path
+             (treemacs--get-or-parse-git-result git-future)))
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
-      (treemacs-with-writable-buffer
-       (save-excursion
-         (goto-char (point-min))
-         (let* ((btn (point)))
-           (while (setf btn (next-button btn))
-             (treemacs--do-apply-annotation btn))))))))
+      (save-excursion
+        (treemacs-with-writable-buffer
+         (let* ((depth (1+ (treemacs-button-get btn :depth)))
+                (git-info (or (ht-get treemacs--git-cache (treemacs-button-get btn :key))
+                              treemacs--empty-table)))
+           ;; the depth check ensures that we only iterate over the nodes that
+           ;; are below parent-btn and stop when we've moved on to nodes that
+           ;; are above or belong to the next project
+           (while (and (setq btn (next-button btn))
+                       (>= (treemacs-button-get btn :depth) depth))
+             (when (= depth (treemacs-button-get btn :depth))
+               (treemacs--do-apply-annotation
+                btn
+                (ht-get git-info (treemacs-button-get btn :key)))))))))))
+
+(define-inline treemacs--do-apply-annotation (btn git-face)
+  "Apply a single BTN's annotations.
+GIT-FACE is taken from the latest git cache, or nil if it's not known."
+  (inline-letevals (btn git-face)
+    (inline-quote
+     (let* ((path (treemacs-button-get ,btn :key))
+            (ann (treemacs-get-annotation path))
+            (btn-start (treemacs-button-start ,btn))
+            (btn-end (treemacs-button-end ,btn)))
+       (if (null ann)
+
+           ;; No annotation - just put git face
+           (when ,git-face
+             (put-text-property btn-start btn-end 'face ,git-face)
+             ;; git face must be known for initial render
+             (ht-set!
+              treemacs--annotation-store
+              path
+              (treemacs-annotation->create!
+               :git-face ,git-face
+               :face-value ,git-face)))
+
+         (let ((face-value (treemacs-annotation->face-value ann))
+               (suffix-value (treemacs-annotation->suffix-value ann))
+               (faces (treemacs-annotation->face ann))
+               (old-git-face (treemacs-annotation->git-face ann)))
+
+           ;; Faces
+           (if (eq 'deleted faces)
+               ;; face annotation was deleted - only the git face remains
+               ;; as the annotation value
+               (progn
+                 (setf
+                  (treemacs-annotation->face ann) nil
+                  (treemacs-annotation->face-value ann) ,git-face
+                  (treemacs-annotation->git-face ann) ,git-face)
+                 (unless ,git-face
+                   (treemacs--remove-annotation-if-empty ann path))
+                 (put-text-property
+                  btn-start btn-end 'face
+                  ,git-face))
+             ;; annotations are present, value needs updating if the git face
+             ;; has changed
+             (let ((new-face-value
+                    (cond
+                     ((and ,git-face (not (equal ,git-face old-git-face)))
+                      (append (mapcar #'cdr faces)
+                              (list ,git-face)))
+                     ((and old-git-face (null ,git-face))
+                      (mapcar #'cdr faces))
+                     (t face-value))))
+               (when new-face-value
+                 (setf
+                  (treemacs-annotation->face-value ann)
+                  new-face-value
+                  (treemacs-annotation->git-face ann)
+                  ,git-face)
+                 (put-text-property
+                  btn-start btn-end 'face
+                  new-face-value))))
+
+           ;; Suffix
+           (goto-char ,btn)
+           (goto-char (or (next-single-property-change
+                           ,btn
+                           'treemacs-suffix-annotation
+                           (current-buffer)
+                           (point-at-eol))
+                          btn-end))
+           (delete-region (point) (point-at-eol))
+           (when suffix-value (insert suffix-value))))))))
+
+(defun treemacs-apply-annotations (path)
+  "Apply annotations for all nodes under the given PATH.
+
+PATH: Node Path"
+  (treemacs-run-in-all-derived-buffers
+   (treemacs-with-writable-buffer
+    (save-excursion
+      (goto-char (treemacs-find-node path))
+      (let ((git-info (ht-get treemacs--git-cache path treemacs--empty-table))
+            (btn (point)))
+        (treemacs--do-apply-annotation
+         btn
+         (ht-get git-info (treemacs-button-get btn :key)))
+        (while (and (setf btn (next-button btn))
+                    (/= 0 (treemacs-button-get btn :depth)))
+          (-let [parent-path (treemacs-button-get
+                              (treemacs-button-get btn :parent)
+                              :key)]
+            (treemacs--do-apply-annotation
+             btn
+             (ht-get
+              (ht-get treemacs--git-cache parent-path git-info)
+              (treemacs-button-get btn :key))))))))))
 
 (provide 'treemacs-annotations)
 

--- a/src/elisp/treemacs-annotations.el
+++ b/src/elisp/treemacs-annotations.el
@@ -71,6 +71,12 @@ PATH: Node Path"
                 (null (treemacs-annotation->suffix ,ann)))
        (ht-remove! treemacs--annotation-store ,path)))))
 
+(define-inline treemacs--delete-annotation (path)
+  "Complete delete annotation information for PATH."
+  (inline-letevals (path)
+    (inline-quote
+     (ht-remove! treemacs--annotation-store ,path))))
+
 ;;; Faces
 
 (define-inline treemacs-set-annotation-face (path face source)

--- a/src/elisp/treemacs-annotations.el
+++ b/src/elisp/treemacs-annotations.el
@@ -1,0 +1,179 @@
+;;; treemacs.el --- A tree style file viewer package -*- lexical-binding: t -*-
+
+;; Copyright (C) 2021 Alexander Miller
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Code for adding, removing, and displaying "annotations" for treemacs'
+;; nodes.  As of now only suffix annotations in extensions are implemented.
+
+;;; Code:
+
+(require 'ht)
+(require 'treemacs-core-utils)
+(require 'treemacs-workspaces)
+
+(eval-when-compile
+  (require 'treemacs-macros)
+  (require 'inline)
+  (require 'cl-lib))
+
+(eval-when-compile
+  (cl-declaim (optimize (speed 3) (safety 0))))
+
+(defconst treemacs--annotation-store (make-hash-table :size 200 :test 'equal))
+(defconst treemacs--annotation-cache (make-hash-table :size 200 :test 'equal))
+
+(cl-defstruct (treemacs-annotation
+               (:conc-name treemacs-annotation->)
+               (:constructor treemacs-annotation->create!)
+               (:copier nil))
+  suffix)
+
+(define-inline treemacs-get-annotation (path)
+  "Get annotation data for the given PATH.
+Will return nil if no annotations exist.
+
+PATH: Node Path"
+  (declare (side-effect-free t))
+  (inline-letevals (path)
+    (inline-quote
+     (ht-get treemacs--annotation-store ,path))))
+
+(define-inline treemacs--create-new-annotation (path)
+  "Create a new empty annotation for PATH and return it."
+  (declare (side-effect-free t))
+  (inline-letevals (path)
+    (inline-quote
+     (let ((ann (treemacs-annotation->create!)))
+       (ht-set! treemacs--annotation-store ,path ann)
+       ann))))
+
+(define-inline treemacs--remove-annotation-if-empty (ann path)
+  "Remove annotation ANN for PATH from the store if it is empty."
+  (inline-letevals (ann path)
+    (inline-quote
+     (when (null (treemacs-annotation->suffix ,ann))
+       (ht-remove! treemacs--annotation-store ,path)))))
+
+(define-inline treemacs-set-annotation-suffix (path suffix source)
+  "Add the given SUFFIX to PATH's annotation.
+Will save the SUFFIX as coming from SOURCE so it can be combined with
+other suffixes.
+
+Source must be a *string* so that multiple suffix annotations on the same node
+can be sorted to always appear in the same order, regardless of when they were
+added.
+
+Treemacs does not prescribe using a specific face for suffix annotations, users
+of this api can propertiue suffixes as they see fit.
+
+PATH: Node Path
+SUFFIX: String
+SOURCE: String"
+  (inline-letevals (source path suffix)
+    (inline-quote
+     (let* ((ann (or (treemacs-get-annotation ,path)
+                     (treemacs--create-new-annotation ,path)))
+            (suffix-list (treemacs-annotation->suffix ann))
+            (old-suffix (--first (string= ,source (car it)) suffix-list)))
+       (put-text-property 0 (length ,suffix) 'treemacs-suffix-annotation t ,suffix)
+       (if old-suffix
+           (setcdr old-suffix ,suffix)
+         (setf (treemacs-annotation->suffix ann)
+               (--sort (string< (car it) (car other))
+                       (cons (cons ,source ,suffix) suffix-list))))))))
+
+(define-inline treemacs-remove-annotation-suffix (path source)
+  "Remove PATH's suffix annotation for the given SOURCE.
+PATH: Node Path
+SOURCE: String"
+  (inline-letevals (path source)
+    (inline-quote
+     (-when-let (ann (treemacs-get-annotation ,path))
+       (let ((suffix-list (treemacs-annotation->suffix ann)))
+         (setf (treemacs-annotation->suffix ann)
+               (--reject-first (string= ,source (car it)) suffix-list)))
+       (treemacs--remove-annotation-if-empty ann ,path)))))
+
+(defun treemacs-clear-annotation-suffixes (source)
+  "Remove all suffix annotations of the given SOURCE."
+    (treemacs--maphash treemacs--annotation-store (path ann)
+      (let ((suffix-list (treemacs-annotation->suffix ann)))
+        (setf (treemacs-annotation->suffix ann)
+              (--reject-first (string= source (car it)) suffix-list))
+        (treemacs--remove-annotation-if-empty ann path))))
+
+;; TODO(2021/08/18): change annotation application such that only a single
+;; timer is needed even if multiple levels have been expanded
+(defun treemacs--apply-annotations-deferred (btn)
+  "Deferred application for annotations for BTN.
+
+Runs on a timer after BTN was expanded and will apply annotations for all of
+BTN's *immediate* children."
+  (-let [buffer (marker-buffer btn)alue]
+    (when (buffer-live-p buffer)
+      (with-current-buffer buffer
+        (save-excursion
+          (treemacs-with-writable-buffer
+           (let* ((btn (treemacs-find-node (treemacs-button-get btn :path)))
+                  (depth (1+ (treemacs-button-get btn :depth))))
+             ;; the depth check ensures that we only iterate over the nodes that
+             ;; are below parent-btn and stop when we've moved on to nodes that
+             ;; are above or belong to the next project
+             (while (and (setq btn (next-button btn))
+                         (>= (treemacs-button-get btn :depth) depth))
+               (when (= depth (treemacs-button-get btn :depth))
+                 (treemacs--do-apply-annotation btn))))))))))
+
+(define-inline treemacs--do-apply-annotation (btn)
+  "Apply a single BTN's annotations."
+  (inline-letevals (btn)
+    (inline-quote
+     (-when-let (ann (treemacs-get-annotation (treemacs-button-get ,btn :path)))
+       (let ((suffix (treemacs--get-annotation-suffix-string ann)))
+         (goto-char ,btn)
+         (goto-char (or (next-single-property-change
+                         ,btn
+                         'treemacs-suffix-annotation
+                         (current-buffer)
+                         (point-at-eol))
+                        (treemacs-button-end ,btn)))
+         (delete-region (point) (point-at-eol))
+         (when suffix (insert suffix)))))))
+
+(define-inline treemacs--get-annotation-suffix-string (ann)
+  "Get the complete, concatenated suffix string from ANN."
+  (declare (side-effect-free t))
+  (inline-letevals (ann)
+    (inline-quote
+     (-when-let (suffix-list (treemacs-annotation->suffix ,ann))
+       (mapconcat #'cdr suffix-list "")))))
+
+(defun treemacs-apply-annotations-in-buffer (buffer)
+  "Apply annotations for all nodes in the given BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (treemacs-with-writable-buffer
+       (save-excursion
+         (goto-char (point-min))
+         (let* ((btn (point)))
+           (while (setf btn (next-button btn))
+             (treemacs--do-apply-annotation btn))))))))
+
+(provide 'treemacs-annotations)
+
+;;; treemacs-annotations.el ends here

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -119,6 +119,9 @@
 (treemacs-import-functions-from "treemacs-persistence"
   treemacs--maybe-load-workspaces)
 
+(treemacs-import-functions-from "treemacs-annotations"
+  treemacs--delete-annotation)
+
 (declare-function treemacs-mode "treemacs-mode")
 
 (defconst treemacs--empty-table (ht)
@@ -427,6 +430,7 @@ being edited to trigger."
   (inline-letevals (path no-buffer-delete)
     (inline-quote
      (progn
+       (treemacs--delete-annotation ,path)
        (unless ,no-buffer-delete (treemacs--kill-buffers-after-deletion ,path t))
        (treemacs--stop-watching ,path t)
        ;; filewatch mode needs the node's information to be in the dom

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -121,6 +121,10 @@
 
 (declare-function treemacs-mode "treemacs-mode")
 
+(defconst treemacs--empty-table (ht)
+  "Constant value of an empty hash table.
+Used to avoid creating unnecessary garbage.")
+
 (defvar treemacs--closed-node-states
   '(root-node-closed
     dir-node-closed

--- a/src/elisp/treemacs-faces.el
+++ b/src/elisp/treemacs-faces.el
@@ -152,6 +152,11 @@ Applies to buttons like
   "Face used to indicate that `treemacs-peek-mode' is enabled."
   :group 'treemacs-faces)
 
+(defface treemacs-marked-file-face
+  '((t :foreground "#F0C674" :background "#AB3737" :bold t))
+  "Face for files marked by treemacs."
+  :group 'treemacs-faces)
+
 (provide 'treemacs-faces)
 
 ;;; treemacs-faces.el ends here

--- a/src/elisp/treemacs-file-management.el
+++ b/src/elisp/treemacs-file-management.el
@@ -25,15 +25,21 @@
 ;;; Code:
 
 (require 'dash)
+(require 'hydra)
 (require 'treemacs-core-utils)
 (require 'treemacs-visuals)
 (require 'treemacs-filewatch-mode)
 (require 'treemacs-logging)
 (require 'treemacs-rendering)
+(require 'treemacs-annotations)
 
 (eval-when-compile
   (require 'inline)
   (require 'treemacs-macros))
+
+(defconst treemacs--mark-annotation-source "treemacs-marked-paths")
+
+(defvar-local treemacs--marked-paths nil)
 
 (with-eval-after-load 'recentf
 
@@ -108,81 +114,201 @@ they will instead be wiped irreversibly."
 (make-obsolete #'treemacs-delete #'treemacs-delete-file "v2.9.3")
 
 ;;;###autoload
+(defun treemacs-delete-marked-files (&optional arg)
+  "Delete all marked files.
+
+A delete action must always be confirmed.  Directories are deleted recursively.
+By default files are deleted by moving them to the trash.  With a prefix ARG
+they will instead be wiped irreversibly.
+
+For marking files see `treemacs-bulk-file-actions'."
+  (interactive "P")
+  (treemacs-block
+   (let ((delete-by-moving-to-trash (not arg))
+         (to-delete (-filter #'file-exists-p treemacs--marked-paths)))
+
+     (treemacs-error-return-if (null treemacs--marked-paths)
+       "There are no marked files")
+
+     (unless (yes-or-no-p (format "Really delete %s marked files"
+                                  (length to-delete)))
+       (treemacs-return (treemacs-log "Cancelled.")))
+
+     (treemacs--without-filewatch
+      (dolist (path to-delete)
+        ;; 2nd check in case of recursive deletes
+        (when (file-exists-p path)
+          (cond
+           ((or (file-symlink-p path) (file-regular-p path))
+            (delete-file path delete-by-moving-to-trash))
+           ((file-directory-p path)
+            (delete-directory path t delete-by-moving-to-trash))))
+        (treemacs--on-file-deletion path)
+        (treemacs-without-messages
+         (treemacs-run-in-every-buffer
+          (treemacs-delete-single-node path)))
+        (run-hook-with-args 'treemacs-delete-file-functions path))
+      (treemacs--evade-image)
+      (setf treemacs--marked-paths (-difference treemacs--marked-paths to-delete))
+      (treemacs-log "Deleted %s files." (length to-delete))))))
+
+;;;###autoload
 (defun treemacs-move-file ()
-  "Move file (or directory) at point.
-Destination may also be a filename, in which case the moved file will also
-be renamed."
+  "Move file (or directory) at point."
   (interactive)
-  (treemacs--copy-or-move :move))
+  (treemacs--copy-or-move
+   :action 'move
+   :no-node-msg "There is nothing to move here."
+   :wrong-type-msg "Only files and directories can be moved."
+   :action-fn #'rename-file
+   :prompt "Move to: "
+   :flat-prompt "File to copy: "
+   :finish-verb "Moved"))
 
 ;;;###autoload
 (defun treemacs-copy-file ()
-  "Copy file (or directory) at point.
-Destination may also be a filename, in which case the copied file will also
-be renamed."
+  "Copy file (or directory) at point."
   (interactive)
-  (treemacs--copy-or-move :copy))
+  (treemacs--copy-or-move
+   :action 'copy
+   :no-node-msg "There is nothing to move here."
+   :wrong-type-msg "Only files and directories can be copied."
+   :action-fn (lambda (from to)
+                (if (file-directory-p from)
+                    (copy-directory from to)
+                  (copy-file from to)))
+   :prompt "Copy to: "
+   :flat-prompt "File to copy: "
+   :finish-verb "Copied"))
 
-(defun treemacs--copy-or-move (action)
-  "Internal implementation for copying and moving files.
-ACTION will be either `:copy' or `:move', depending on whether we are calling
-from `treemacs-copy-file' or `treemacs-move-file'."
-  (let ((no-node-msg)
-        (wrong-type-msg)
-        (prompt)
-        (action-function)
-        (finish-msg))
-    (pcase action
-      (:copy
-       (setf no-node-msg     "There is nothing to copy here."
-             wrong-type-msg  "Only files and directories can be copied."
-             prompt          "Copy to: "
-             action-function (lambda (from to)
-                               (if (file-directory-p from)
-                                   (copy-directory from to)
-                                 (copy-file from to)))
-             finish-msg      "Copied %s to %s"))
-      (:move
-       (setf no-node-msg     "There is nothing to move here."
-             wrong-type-msg  "Only files and directories can be moved."
-             prompt          "Move to: "
-             action-function #'rename-file
-             finish-msg      "Moved %s to %s")))
-    (treemacs-block
-     (treemacs-unless-let (node (treemacs-node-at-point))
-         (treemacs-error-return no-node-msg)
-       (treemacs-error-return-if (not (treemacs-is-node-file-or-dir? node))
-         wrong-type-msg)
-       (let* ((source (treemacs--select-file-from-btn
-                       node
-                       (if (eq action :copy) "File to copy: " "File to move: ")))
-              (source-name (treemacs--filename source))
-              (destination (treemacs--unslash (read-file-name prompt nil default-directory)))
-              (target-is-dir? (file-directory-p destination))
-              (target-name (if target-is-dir? (treemacs--filename source) (treemacs--filename destination)))
-              (destination-dir (if target-is-dir? destination (treemacs--parent-dir destination)))
-              (target (treemacs--find-repeated-file-name (treemacs-join-path destination-dir target-name))))
-         (unless (file-exists-p destination-dir)
-           (make-directory destination-dir :parents))
-         (when (eq action :move)
-           ;; do the deletion *before* moving the file, otherwise it will no longer exist and treemacs will
-           ;; not recognize it as a file path
-           (treemacs-do-delete-single-node source))
-         (treemacs--without-filewatch
-          (funcall action-function source target))
-         ;; no waiting for filewatch, if we copied to an expanded directory refresh it immediately
-         (-let [parent (treemacs--parent target)]
-           (when (treemacs-is-path-visible? parent)
-             (treemacs-do-update-node parent)))
-         (treemacs-goto-file-node target)
-         (run-hook-with-args
-          (pcase action
-            (:copy 'treemacs-copy-file-functions)
-            (:move 'treemacs-move-file-functions))
-          source target)
-         (treemacs-pulse-on-success finish-msg
-           (propertize source-name 'face 'font-lock-string-face)
-           (propertize destination 'face 'font-lock-string-face)))))))
+(cl-defun treemacs--copy-or-move
+    (&key
+     action
+     no-node-msg
+     wrong-type-msg
+     action-fn
+     prompt
+     flat-prompt
+     finish-verb)
+  "Internal implementation for copying and moving files."
+  (treemacs-block
+   (let ((btn (treemacs-current-button)))
+     (treemacs-error-return-if (null btn)
+       no-node-msg)
+     (treemacs-error-return-if
+         (not (memq (treemacs-button-get btn :state)
+                    '(file-node-open file-node-closed dir-node-open dir-node-closed)))
+       wrong-type-msg)
+     (let* ((source (treemacs--select-file-from-btn btn flat-prompt))
+            (destination-dir (treemacs--canonical-path
+                              (read-directory-name prompt nil default-directory)))
+            (target (->> source
+                         (treemacs--filename)
+                         (treemacs-join-path destination-dir)
+                         (treemacs--find-repeated-file-name))))
+       (unless (file-exists-p destination-dir)
+         (make-directory destination-dir :parents))
+       (when (eq action 'move)
+         ;; do the deletion *before* moving the file, otherwise it will
+         ;; no longer exist and treemacs will not recognize it as a file path
+         (treemacs-do-delete-single-node source))
+       (treemacs--without-filewatch
+        (funcall action-fn source target))
+       (pcase action
+         ('move
+          (run-hook-with-args 'treemacs-copy-file-functions source target)
+          (treemacs--on-file-deletion source))
+         ('copy
+          (run-hook-with-args 'treemacs-move-file-functions source target)
+          (treemacs-remove-annotation-face source "treemacs-marked-paths")))
+
+       (treemacs-update-node destination-dir)
+
+       (when (treemacs-is-path target :in-workspace)
+         (treemacs-goto-file-node target))
+
+       (treemacs-pulse-on-success "%s %s to %s"
+         finish-verb
+         (propertize (treemacs--filename target) 'face 'font-lock-string-face)
+         (propertize destination-dir 'face 'font-lock-string-face))))))
+
+;;;###autoload
+(defun treemacs-move-marked-files ()
+  "Move all marked files.
+
+For marking files see `treemacs-bulk-file-actions'."
+  (interactive)
+  (treemacs--bulk-copy-or-move
+   :action 'move
+   :action-fn #'rename-file
+   :prompt "Move to: "
+   :finish-verb "Moved"))
+
+;;;###autoload
+(defun treemacs-copy-marked-files ()
+  "Copy all marked files.
+
+For marking files see `treemacs-bulk-file-actions'."
+  (interactive)
+  (treemacs--bulk-copy-or-move
+   :action 'copy
+   :action-fn (lambda (from to)
+                (if (file-directory-p from)
+                    (copy-directory from to)
+                  (copy-file from to)))
+   :prompt "Copy to: "
+   :finish-verb "Copied"))
+
+(cl-defun treemacs--bulk-copy-or-move
+    (&key
+     action
+     action-fn
+     prompt
+     finish-verb)
+  "Internal implementation for bulk-copying and -moving files."
+  (treemacs-block
+   (let* ((to-move (-filter #'file-exists-p treemacs--marked-paths))
+          (destination-dir (treemacs--canonical-path
+                            (read-directory-name prompt nil default-directory)))
+          (projects (->> to-move
+                         (-map #'treemacs--find-project-for-path)
+                         (cl-remove-duplicates)
+                         (-filter #'identity))))
+     (treemacs-save-position
+      (dolist (source to-move)
+        (let ((target (->> source
+                           (treemacs--filename)
+                           (treemacs-join-path destination-dir)
+                           (treemacs--find-repeated-file-name))))
+          (unless (string= source target)
+            (unless (file-exists-p destination-dir)
+              (make-directory destination-dir :parents))
+            (when (eq action 'move)
+              ;; do the deletion *before* moving the file, otherwise it will
+              ;; no longer exist and treemacs will not recognize it as a file path
+              (treemacs-do-delete-single-node source))
+            (treemacs--without-filewatch
+             (funcall action-fn source target))
+            (pcase action
+              ('move
+               (run-hook-with-args 'treemacs-copy-file-functions source target)
+               (treemacs--on-file-deletion source))
+              ('copy
+               (run-hook-with-args 'treemacs-move-file-functions source target)
+               (treemacs-remove-annotation-face source "treemacs-marked-paths"))))))
+
+      (dolist (project projects)
+        (treemacs-project->refresh! project)))
+
+     (when (treemacs-is-path destination-dir :in-workspace)
+       (treemacs-goto-file-node destination-dir))
+
+     (setf treemacs--marked-paths (-difference treemacs--marked-paths to-move))
+
+     (treemacs-pulse-on-success "%s %s files to %s"
+       finish-verb
+       (propertize (number-to-string (length to-move)) 'face 'font-lock-constant-face)
+       (propertize destination-dir 'face 'font-lock-string-face)))))
 
 ;;;###autoload
 (cl-defun treemacs-rename-file ()
@@ -234,6 +360,98 @@ will likewise be updated."
 
 (defalias 'treemacs-rename #'treemacs-rename-file)
 (make-obsolete #'treemacs-rename #'treemacs-rename-file "v2.9.3")
+
+;;; Bulk Actions
+
+;;;###autoload
+(defun treemacs-show-marked-files ()
+  "Print a list of all files marked by treemacs."
+  (interactive)
+  (if (null treemacs--marked-paths)
+      (treemacs-log "There are currently no marked files.")
+    (treemacs-log "There are currently %s marked file(s):"
+      (length treemacs--marked-paths))
+    (dolist (path treemacs--marked-paths)
+      (treemacs-log "%s" path))))
+
+;;;###autoload
+(defun treemacs-mark-or-unmark-path-at-point ()
+  "Marks or unmarks the absolute path of the node at point."
+  (interactive)
+  (treemacs-block
+   (-let [path (treemacs--prop-at-point :path)]
+     (treemacs-error-return-if (null path)
+       "There is nothing to mark here")
+     (treemacs-error-return-if
+         (or (not (stringp path)) (not (file-exists-p path)))
+       "Path at point is not a file or directory.")
+     (if (member path treemacs--marked-paths)
+         (progn
+           (setq treemacs--marked-paths
+                 (remove path treemacs--marked-paths))
+           (treemacs-log "Unmarked path: %s" (propertize path 'face 'font-lock-string-face))
+           (treemacs-remove-annotation-face path "treemacs-marked-paths"))
+       (progn
+         (setq treemacs--marked-paths
+               (append treemacs--marked-paths (list path)))
+         (treemacs-log "Marked path: %s" (propertize path 'face 'font-lock-string-face))
+         (treemacs-set-annotation-face path 'treemacs-marked-file-face "treemacs-marked-paths")))
+     (treemacs-apply-annotations (treemacs--parent-dir path)))))
+
+;;;###autoload
+(defun treemacs-reset-marks ()
+  "Removes all previously made marks in the current buffer."
+  (interactive)
+  (let ((count (length treemacs--marked-paths))
+        (projects))
+    (dolist (path treemacs--marked-paths)
+      (treemacs-remove-annotation-face path treemacs--mark-annotation-source)
+      (push (treemacs--find-project-for-path path) projects))
+    (setf treemacs--marked-paths nil)
+    (dolist (project (-uniq projects))
+      (treemacs-apply-annotations (treemacs-project->path project)))
+    (treemacs-pulse-on-success "Unmarked %s file(s)." count)))
+
+;;;###autoload
+(defun treemacs-delete-marked-paths ()
+  (interactive)
+  (treemacs-save-position
+   (when (yes-or-no-p
+          (format "Really delete %s marked file(s)?"
+                  (length treemacs--marked-paths)))
+     (-let [count (length treemacs--marked-paths)]
+       (dolist (path treemacs--marked-paths)
+         (if (file-directory-p path)
+             (delete-directory path t)
+           (delete-file path))
+         (treemacs-do-delete-single-node path)
+         (treemacs-remove-annotation-face path treemacs--mark-annotation-source))
+       (setf treemacs--marked-paths nil)
+       (hl-line-highlight)
+       (treemacs-log "Deleted %s files." count)))))
+
+;; shut down docstring width warnings
+(with-no-warnings
+  (defhydra treemacs-bulk-file-actions-hydra (:exit t :hint nil)
+    ("m" #'treemacs-mark-or-unmark-path-at-point "(un)mark")
+    ("u" #'treemacs-reset-marks "unmark all")
+    ("s" #'treemacs-show-marked-files "show")
+    ("d" #'treemacs-delete-marked-files "delete")
+    ("c" #'treemacs-copy-marked-files "copy")
+    ("o" #'treemacs-move-marked-files "move")
+    ("q" nil "cancel")))
+
+;;;###autoload
+(defun treemacs-bulk-file-actions ()
+  "Activate the bulk file actions hydra.
+This interface allows to quickly (unmark) files, so as to copy, move or delete
+them in bulk.
+
+Note that marking files is *permanent*, files will stay marked until they are
+either manually unmarked or deleted. You can show a list of all currently marked
+files with `treemacs-show-marked-files' or `s' in the hydra."
+  (interactive)
+  (treemacs-bulk-file-actions-hydra/body))
 
 ;;;###autoload
 (defun treemacs-create-file ()

--- a/src/elisp/treemacs-filewatch-mode.el
+++ b/src/elisp/treemacs-filewatch-mode.el
@@ -158,7 +158,7 @@ An event counts as relevant when
                        (let* ((file (caddr ,event))
                               (parent (treemacs--parent-dir file))
                               (cache (ht-get treemacs--git-cache parent)))
-                         (and cache (not (string= "!" (ht-get cache file))))))
+                         (and cache (not (eq 'treemacs-git-ignored-face (ht-get cache file))))))
                   (let* ((dir (caddr ,event))
                          (filename (treemacs--filename dir)))
                     (--any? (funcall it filename dir) treemacs-ignored-file-predicates)))))))))

--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -200,6 +200,7 @@ Will be set by `treemacs--post-command'.")
     (define-key map (kbd "C")         'treemacs-cleanup-litter)
     (define-key map (kbd "=")         'treemacs-fit-window-width)
     (define-key map (kbd "W")         'treemacs-extra-wide-toggle)
+    (define-key map (kbd "M-m")       'treemacs-bulk-file-actions-hydra/body)
     map)
   "Keymap for `treemacs-mode'.")
 

--- a/src/elisp/treemacs-rendering.el
+++ b/src/elisp/treemacs-rendering.el
@@ -33,6 +33,7 @@
 (require 'treemacs-workspaces)
 (require 'treemacs-visuals)
 (require 'treemacs-logging)
+(require 'treemacs-annotations)
 
 (eval-when-compile
   (require 'cl-lib)
@@ -412,10 +413,14 @@ set to PARENT."
             (setf git-info (treemacs--get-or-parse-git-result ,git-future))
             (ht-set! treemacs--git-cache ,root git-info))
            ('deferred
-             (setq git-info (or (ht-get treemacs--git-cache ,root) (ht)))
-             (run-with-timer 0.5 nil #'treemacs--apply-deferred-git-state ,parent ,git-future (current-buffer)))
+             (setf git-info (or (ht-get treemacs--git-cache ,root) treemacs--empty-table)))
            (_
-            (setq git-info (ht))))
+            (setf git-info treemacs--empty-table)))
+
+         (run-with-timer
+          0.5 nil
+          #'treemacs--apply-annotations-deferred
+          ,parent ,root (current-buffer) ,git-future)
 
          (if treemacs-pre-file-insert-predicates
              (progn
@@ -460,7 +465,9 @@ set to PARENT."
             0
             (length it)
             'face
-            (treemacs--get-node-face (concat ,root "/" it) git-info 'treemacs-directory-face)
+            (if-let* ((ann (treemacs-get-annotation (concat ,root "/" it))))
+                (treemacs-annotation->face-value ann)
+              'treemacs-directory-face)
             it))
          (insert (apply #'concat dir-strings))
 
@@ -470,7 +477,9 @@ set to PARENT."
             0
             (length it)
             'face
-            (treemacs--get-node-face (concat ,root "/" it) git-info 'treemacs-git-unmodified-face)
+            (if-let* ((ann (treemacs-get-annotation (concat ,root "/" it))))
+                (treemacs-annotation->face-value ann)
+              'treemacs-git-unmodified-face)
             it))
          (insert (apply #'concat file-strings))
 
@@ -630,6 +639,7 @@ PROJECT: Project Struct"
                  'category 'default-button
                  'face (treemacs--root-face project)
                  :project project
+                 :key path
                  :symlink (when (treemacs-project->is-readable? project)
                             (file-symlink-p path))
                  :state 'root-node-closed

--- a/src/elisp/treemacs.el
+++ b/src/elisp/treemacs.el
@@ -48,6 +48,7 @@
 (require 'treemacs-fringe-indicator)
 (require 'treemacs-header-line)
 (require 'treemacs-extensions)
+(require 'treemacs-annotations)
 
 (defconst treemacs-version
   (eval-when-compile

--- a/src/extra/treemacs-magit.el
+++ b/src/extra/treemacs-magit.el
@@ -131,13 +131,19 @@ Will update nodes under MAGIT-ROOT with output in PFUTURE-BUFFER."
                           (or (not (stringp path))
                               (file-exists-p path))
                           (>= curr-depth start-depth))
+                (treemacs--git-face-quick-change
+                    (treemacs-button-get node :key)
+                    (or (ht-get ht path)
+                        (if (memq (treemacs-button-get node :state)
+                                  '(file-node-open file-node-closed))
+                            'treemacs-git-unmodified-face
+                          'treemacs-directory-face)))
                 (put-text-property (treemacs-button-start node) (treemacs-button-end node) 'face
-                                   (treemacs--get-node-face
-                                    path ht
-                                    (if (memq (treemacs-button-get node :state)
-                                              '(file-node-open file-node-closed))
-                                        'treemacs-git-unmodified-face
-                                      'treemacs-directory-face)))
+                                   (or (ht-get ht path)
+                                       (if (memq (treemacs-button-get node :state)
+                                                 '(file-node-open file-node-closed))
+                                           'treemacs-git-unmodified-face
+                                         'treemacs-directory-face)))
                 (forward-line 1)
                 (if (eobp)
                     (setf node nil)

--- a/src/scripts/treemacs-git-status.py
+++ b/src/scripts/treemacs-git-status.py
@@ -23,11 +23,27 @@ QUOTE        = b'"'
 output       = []
 ht_size      = 0
 
+def face_for_status(status):
+    if status == b"M":
+        return b"treemacs-git-modified-face"
+    elif status == b"U":
+        return b"treemacs-git-conflict-face"
+    elif status == b"?":
+        return b"treemacs-git-untracked-face"
+    elif status == b"!":
+        return b"treemacs-git-ignored-face"
+    elif status == b"A":
+        return b"treemacs-git-added-face"
+    elif status == b"R":
+        return b"treemacs-git-renamed-face"
+    else:
+        return b"font-lock-keyword-face"
+
 def find_recursive_entries(path, state):
     global output, ht_size
     for item in listdir(path):
         full_path = join(path, item)
-        output.append(full_path + QUOTE + QUOTE + state)
+        output.append(QUOTE + full_path + QUOTE + face_for_status(state))
         ht_size += 1
         if ht_size > LIMIT:
             break
@@ -69,7 +85,7 @@ def main():
         if abs_path.endswith(b'/'):
             abs_path = abs_path[:-1]
             dirs_added[abs_path] = True
-        output.append(abs_path + QUOTE + QUOTE + state)
+        output.append(QUOTE + abs_path + QUOTE + face_for_status(state))
         ht_size += 1
 
         # for files deeper down in the file hierarchy also print all their directories
@@ -83,7 +99,7 @@ def main():
                 # directories should not be printed more than once, which would happen if
                 # e.g. both /A/B/C/x and /A/B/C/y have changes
                 if full_dirname not in dirs_added:
-                    output.append(full_dirname + QUOTE + QUOTE + b'M')
+                    output.append(QUOTE + full_dirname + QUOTE + b"treemacs-git-modified-face")
                     ht_size += 1
                     dirs_added[full_dirname] = True
         # for untracked and ignored directories we need to find an entry for every single file
@@ -100,8 +116,8 @@ def main():
         b" test equal rehash-size 1.5 rehash-threshold 0.8125 data ("
     )
     if ht_size > 0:
-      STDOUT.write(QUOTE + (QUOTE + QUOTE).join(output) + QUOTE)
-    STDOUT.write( b"))")
+      STDOUT.write(b"".join(output))
+    STDOUT.write(b"))")
 
     sys.exit(proc.poll())
 


### PR DESCRIPTION
While not technically part of my initial improvement suggestions from #534, I've been struggling with this ever since switching from my last filetree viewer.

The idea is to mark specific paths by navigating to them and pressing a key and once you marked them all, perform the same action on all of them: delete, copy, move, maybe even rename (in the future). Pressing `ESC` (not implemented yet) would technically take you out of the mark selection, and pressing another key would undo this, giving you back your previous selection (reason why I made that `mark-active` variable. Also there should also be (but not yet implemented) a way to visually highlight the marked files, or parent directories in case they're collapsed after marking.

There are may edge cases that I've not handled yet, reason why I haven't exposed the functionality under specific keys.
@Alexander-Miller please take a look at this and leave comments and suggestions. I'll deal with docstrings and the README once we're good. I'd like to introduce this functionality piece by piece, even though it's not complete, and improve on it in future PRs, as it has the potential to be quite big.

In my testing I did:
```elisp
(evil-define-key 'treemacs treemacs-mode-map (kbd "M") #'treemacs-mark-or-unmark-absolute-path-at-point)
(evil-define-key 'treemacs treemacs-mode-map (kbd "N") #'treemacs-reset-mark)
```
Then switched around `N` to the other functions. We'll need to come up with some good keybindings for these as well...
