### PR TITLE
[Icons] Use elx-light for heex (HTML EEx).

### DIFF
--- a/src/elisp/treemacs-icons.el
+++ b/src/elisp/treemacs-icons.el
@@ -339,7 +339,7 @@ Necessary since root icons are not rectangular."
     (treemacs-create-icon :file "json.png"          :extensions ("json"))
     (treemacs-create-icon :file "julia.png"         :extensions ("jl"))
     (treemacs-create-icon :file "elx.png"           :extensions ("ex"))
-    (treemacs-create-icon :file "elx-light.png"     :extensions ("exs" "eex" "leex"))
+    (treemacs-create-icon :file "elx-light.png"     :extensions ("exs" "eex" "leex" "heex"))
     (treemacs-create-icon :file "ocaml.png"         :extensions ("ml" "mli" "merlin" "ocaml"))
     (treemacs-create-icon :file "direnv.png"        :extensions ("envrc"))
     (treemacs-create-icon :file "puppet.png"        :extensions ("pp"))

--- a/src/extra/treemacs-all-the-icons.el
+++ b/src/extra/treemacs-all-the-icons.el
@@ -142,6 +142,7 @@
     (treemacs-create-icon :icon (format "  %s%s" (all-the-icons-faicon "wrench" :v-adjust 0 :face 'all-the-icons-lpurple) treemacs-all-the-icons-tab) :extensions ("envrc") :fallback 'same-as-icon)
     (treemacs-create-icon :icon (format "  %s%s" (all-the-icons-fileicon "eslint" :v-adjust 0 :face 'all-the-icons-lpurple) treemacs-all-the-icons-tab) :extensions ("eslintrc" "eslintcache") :fallback 'same-as-icon)
     (treemacs-create-icon :icon (format "  %s%s" (all-the-icons-octicon "file-binary" :v-adjust 0 :face 'all-the-icons-lsilver) treemacs-all-the-icons-tab) :extensions ("exe" "obj" "so" "o") :fallback 'same-as-icon)
+    (treemacs-create-icon :icon (format "  %s%s" (all-the-icons-alltheicon "elixir" :v-adjust 0 :face 'all-the-icons-dpurple) treemacs-all-the-icons-tab) :extensions ("heex") :fallback 'same-as-icon)
     (treemacs-create-icon :icon (format "  %s%s" (all-the-icons-fileicon "cucumber" :v-adjust 0 :face 'all-the-icons-dgreen) treemacs-all-the-icons-tab) :extensions ("feature") :fallback 'same-as-icon)
     (treemacs-create-icon :icon (format "  %s%s" (all-the-icons-fileicon "fortran" :v-adjust 0 :face 'all-the-icons-lsilver) treemacs-all-the-icons-tab) :extensions ("fortran" "fortran-modern" "fortranfreeform") :fallback 'same-as-icon)
     (treemacs-create-icon :icon (format "  %s%s" (all-the-icons-fileicon "fsharp" :v-adjust 0 :face 'all-the-icons-lblue) treemacs-all-the-icons-tab) :extensions ("fsharp") :fallback 'same-as-icon)


### PR DESCRIPTION
[heex](https://hexdocs.pm/phoenix_live_view/assigns-eex.html#:~:text=.heex%20extension%20(HTML%20EEx)) (HTML EEx) is used as a template for Elixir Phoenix.