### PR TITLE
Use `--ignored=matching` with `git status`

### DIFF
--- a/src/elisp/treemacs-async.el
+++ b/src/elisp/treemacs-async.el
@@ -196,7 +196,7 @@ GIT-FUTURE: Pfuture"
   "Start a simple git status process for files under PATH."
   (let* ((default-directory (file-truename path))
          (process-environment (cons "GIT_OPTIONAL_LOCKS=0" process-environment))
-         (future (pfuture-new "git" "status" "--porcelain" "--ignored" "-z" ".")))
+         (future (pfuture-new "git" "status" "--porcelain" "--ignored=matching" "-z" ".")))
     (process-put future 'default-directory default-directory)
     future))
 

--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -714,8 +714,8 @@ This is only relevant when using the deferred variant of git-mode."
 (defcustom treemacs-max-git-entries 5000
   "Maximum number of git status entries treemacs will process.
 Information for entries that number will be silently ignored.  The 'entries'
-refer to the lines output by `git status --porcelain --ignored'.  The limit does
-not apply to the simple `treemacs-git-mode.'"
+refer to the lines output by `git status --porcelain --ignored=matching'.
+The limit does not apply to the simple `treemacs-git-mode.'"
   :type 'number
   :group 'treemacs-git)
 
@@ -733,13 +733,14 @@ the python3 binary."
 
 (defcustom treemacs-git-command-pipe ""
   "Text to be appended to treemacs' git command.
-With `treemacs-git-mode' the command `git status --porcelain --ignored .' is
-run to fetch a directory's git information.  The content of this variable will
-be appended to this git command.  This might be useful in cases when the output
-produced by git is so large that it leads to palpable delays, while setting
-`treemacs-max-git-entries' leads to loss of information.  In such a scenario an
-additional filter statement (for example `| grep -v \"/vendor_dir/\"') can be
-used to reduce the size of the output to a manageable volume for treemacs."
+With `treemacs-git-mode' the command
+`git status --porcelain --ignored=matching .' is run to fetch a directory's git
+information.  The content of this variable will be appended to this git command.
+This might be useful in cases when the output produced by git is so large that
+it leads to palpable delays, while setting `treemacs-max-git-entries' leads to
+loss of information.  In such a scenario an additional filter statement (for
+example `| grep -v \"/vendor_dir/\"') can be used to reduce the size of the
+output to a manageable volume for treemacs."
   :type 'string
   :group 'treemacs-git)
 

--- a/src/scripts/treemacs-git-status.py
+++ b/src/scripts/treemacs-git-status.py
@@ -16,7 +16,7 @@ import sys
 
 GIT_ROOT     = str.encode(sys.argv[1])
 LIMIT        = int(sys.argv[2])
-GIT_CMD      = "git status --porcelain --ignored . " + sys.argv[3]
+GIT_CMD      = "git status --porcelain --ignored=matching . " + sys.argv[3]
 STDOUT       = sys.stdout.buffer
 RECURSE_DIRS = set([str.encode(it[(len(GIT_ROOT)):]) + b"/" for it in sys.argv[4:]]) if len(sys.argv) > 4 else []
 QUOTE        = b'"'

--- a/src/scripts/treemacs-single-file-git-status.py
+++ b/src/scripts/treemacs-single-file-git-status.py
@@ -10,7 +10,7 @@ FILE = sys.argv[1]
 OLD_STATE = sys.argv[2]
 PARENTS = [p for p in sys.argv[3:]]
 
-FILE_STATE_CMD = "git status --porcelain --ignored "
+FILE_STATE_CMD = "git status --porcelain --ignored=matching "
 IS_IGNORED_CMD = "git check-ignore "
 IS_TRACKED_CMD = "git ls-files --error-unmatch "
 IS_CHANGED_CMD = "git diff-index --quiet HEAD "


### PR DESCRIPTION
The default `--ignored[=traditional]` seems to recursively visit all
files within a project even if `--untracked-files=all` is not
supplied. This may take a lot of time for project with a very large
tree where the root node is ignored.

See #921 for a more thorough explanation.