### PR TITLE
Fix README Typo

### DIFF
--- a/README.org
+++ b/README.org
@@ -446,7 +446,7 @@ discoverability.
             treemacs-find-workspace-method           'find-for-file-or-pick-first
             treemacs-git-command-pipe                ""
             treemacs-goto-tag-strategy               'refetch-index
-            treemacs-header-scroll-indicators        '(nil . "^^^^^^")'
+            treemacs-header-scroll-indicators        '(nil . "^^^^^^")
             treemacs-hide-dot-git-directory          t
             treemacs-indentation                     2
             treemacs-indentation-string              " "


### PR DESCRIPTION
Noticed this on a fresh install of treemacs

Causes `Error (use-package): treemacs/:config: Wrong type argument: symbolp, 'treemacs-hide-dot-git-directory`