### PR TITLE
Fix emacs native compilation warnings

### DIFF
--- a/src/elisp/treemacs-annotations.el
+++ b/src/elisp/treemacs-annotations.el
@@ -317,9 +317,9 @@ GIT-FACE is taken from the latest git cache, or nil if it's not known."
                            ,btn
                            'treemacs-suffix-annotation
                            (current-buffer)
-                           (point-at-eol))
+                           (line-end-position))
                           btn-end))
-           (delete-region (point) (point-at-eol))
+           (delete-region (point) (line-end-position))
            (when suffix-value (insert suffix-value))))))))
 
 (defun treemacs-apply-single-annotation (path)

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -209,7 +209,7 @@ If STR already has a slash return it unchanged."
   "Delete the current line.
 Unlike the function `kill-whole-line' this won't pollute the kill ring."
   (inline-quote
-     (delete-region (point-at-bol) (min (point-max) (1+ (point-at-eol))))))
+    (delete-region (line-beginning-position) (min (point-max) (1+ (line-end-position))))))
 
 (define-inline treemacs-current-button ()
   "Get the button in the current line.
@@ -217,7 +217,7 @@ Returns nil when point is between projects."
   (declare (side-effect-free error-free))
   (inline-quote
    (-some->
-    (text-property-not-all (point-at-bol) (point-at-eol) 'button nil)
+    (text-property-not-all (line-beginning-position) (line-end-position) 'button nil)
     (copy-marker t))))
 (defalias 'treemacs-node-at-point #'treemacs-current-button)
 
@@ -324,7 +324,7 @@ EXCLUDE-PREFIX: File Path"
     (inline-quote
      (save-excursion
        (let ((len (length ,new-symbol)))
-         (goto-char (- (treemacs-button-start (next-button (point-at-bol) t)) len))
+         (goto-char (- (treemacs-button-start (next-button (line-beginning-position) t)) len))
          (insert ,new-symbol)
          (delete-char len))))))
 
@@ -632,7 +632,7 @@ failed.  PROJECT is used for determining whether Git actions are appropriate."
                        ;; first a plain text-based search for the current dir-part string
                        ;; then we grab the node we landed at and see what's going on
                        ;; there's a couple ways this can go
-                       (while (progn (goto-char (point-at-eol)) (search-forward dir-part nil :no-error))
+                       (while (progn (goto-char (line-end-position)) (search-forward dir-part nil :no-error))
                          (setq current-btn (treemacs-current-button))
                          (cond
                           ;; somehow we landed on a line where there isn't even anything to look at

--- a/src/elisp/treemacs-fringe-indicator.el
+++ b/src/elisp/treemacs-fringe-indicator.el
@@ -42,7 +42,7 @@
   "Move the fringe indicator to the position of point."
   (inline-quote
    (when treemacs--fringe-indicator-overlay
-     (-let [pabol (point-at-bol)]
+     (-let [pabol (line-beginning-position)]
        (move-overlay treemacs--fringe-indicator-overlay pabol  (1+ pabol))))))
 
 (defun treemacs--enable-fringe-indicator ()

--- a/src/elisp/treemacs-interface.el
+++ b/src/elisp/treemacs-interface.el
@@ -708,7 +708,7 @@ For slower scrolling see `treemacs-previous-line-other-window'"
            (treemacs--forget-last-highlight)
            ;; after renaming, delete and redisplay the project
            (goto-char (treemacs-button-end project-btn))
-           (delete-region (point-at-bol) (point-at-eol))
+           (delete-region (line-beginning-position) (line-end-position))
            (treemacs--add-root-element project)
            (when (eq state 'root-node-open)
              (treemacs--collapse-root-node (treemacs-project->position project))
@@ -1264,7 +1264,7 @@ visible."
     (save-excursion
       (goto-char (point-min))
       (while (= 0 (forward-line 1))
-        (-let [new-len (- (point-at-eol) (point-at-bol))]
+        (-let [new-len (- (line-end-position) (line-beginning-position))]
           (when (> new-len longest)
             (setf longest new-len
                   depth (treemacs--prop-at-point :depth))))))

--- a/src/elisp/treemacs-rendering.el
+++ b/src/elisp/treemacs-rendering.el
@@ -110,7 +110,7 @@ is a marker pointing to POS."
   "Get the current screen line in the selected window."
   (declare (side-effect-free t))
   (inline-quote
-   (max 1 (count-screen-lines (window-start) (point-at-eol)))))
+   (max 1 (count-screen-lines (window-start) (line-end-position)))))
 
 (define-inline treemacs--lines-in-window ()
   "Determine the number of lines visible in the current (treemacs) window.
@@ -518,7 +518,7 @@ set to PARENT."
          (save-excursion
            (treemacs--flatten-dirs (treemacs--parse-collapsed-dirs ,collapse-process))
            (treemacs--reentry ,root ,git-future))
-         (point-at-eol))))))
+         (line-end-position))))))
 
 (cl-defmacro treemacs--button-close (&key button new-icon new-state post-close-action)
   "Close node given by BUTTON, use NEW-ICON and BUTTON's state to NEW-STATE.
@@ -538,7 +538,7 @@ Run POST-CLOSE-ACTION after everything else is done."
           ;; current button, making the treemacs--projects-end marker track
           ;; properly when collapsing the last project or a last directory of the
           ;; last project.
-          (let* ((pos-start (point-at-eol))
+          (let* ((pos-start (line-end-position))
                  (next (treemacs--next-non-child-button ,button))
                  (pos-end (if next
                               (-> next (treemacs-button-start) (previous-button) (treemacs-button-end))
@@ -984,7 +984,7 @@ FLATTEN-INFO [Int File Path...]"
 
          ;; Insert new label
          (goto-char parent-btn)
-         (delete-region (point) (point-at-eol))
+         (delete-region (point) (line-end-position))
          (insert (apply #'propertize new-button-label properties))
 
          ;; Fixing marker probably necessary since it's also in the dom

--- a/src/elisp/treemacs-visuals.el
+++ b/src/elisp/treemacs-visuals.el
@@ -80,7 +80,7 @@ Used to save the values of `treemacs-indentation' and
           (when treemacs-fringe-indicator-mode
             (treemacs--move-fringe-indicator-to-point))
           (-when-let (btn (treemacs-current-button))
-            (let* ((pos (max (point-at-bol) (- (treemacs-button-start btn) 2)))
+            (let* ((pos (max (line-beginning-position) (- (treemacs-button-start btn) 2)))
                    (img-selected (get-text-property pos 'img-selected)))
               (treemacs-with-writable-buffer
                (when (and treemacs--last-highlight
@@ -99,7 +99,7 @@ Used to save the values of `treemacs-indentation' and
   (when (eq 'treemacs-mode major-mode)
     (treemacs-with-writable-buffer
      (-when-let (btn (treemacs-current-button))
-       (let* ((start (max (point-at-bol) (- (treemacs-button-start btn) 2)))
+       (let* ((start (max (line-beginning-position) (- (treemacs-button-start btn) 2)))
               (end (1+ start))
               (img (get-text-property start 'display))
               (cp (copy-sequence img)))

--- a/src/elisp/treemacs-workspaces.el
+++ b/src/elisp/treemacs-workspaces.el
@@ -223,13 +223,13 @@ FILE: Filepath"
   "Get the position of the next project.
 Will return `point-max' if there is no next project."
   (declare (side-effect-free t))
-  (inline-quote (next-single-char-property-change (point-at-eol) :project)))
+  (inline-quote (next-single-char-property-change (line-end-position) :project)))
 
 (define-inline treemacs--prev-project-pos ()
   "Get the position of the next project.
 Will return `point-min' if there is no next project."
   (declare (side-effect-free t))
-  (inline-quote (previous-single-char-property-change (point-at-bol) :project)))
+  (inline-quote (previous-single-char-property-change (line-beginning-position) :project)))
 
 (define-inline treemacs--reset-project-positions ()
   "Reset `treemacs--project-positions'."
@@ -595,7 +595,7 @@ Return values may be as follows:
           ;; the end of the previous button's line. If the `treemacs--projects-end'
           ;; is at the EOL of the  it will move to EOL of the previous button.
           (previous-button
-           (delete-region (treemacs-button-end previous-button) (point-at-eol))
+           (delete-region (treemacs-button-end previous-button) (line-end-position))
            (when next-button (forward-button 1)))
           ;; Previous project does not exist, but a next button exists. Delete from
           ;; BOL to the start of the next buttons line.
@@ -604,12 +604,12 @@ Return values may be as follows:
              ;; The first item after the deletion will be bottom extensions. Project
              ;; end will be at its BOL, making it move upon expand/collapse. Lock the marker.
              (set-marker-insertion-type (treemacs--projects-end) nil))
-           (delete-region (point-at-bol) (progn (goto-char next-button) (forward-line 0) (point))))
+           (delete-region (line-beginning-position) (progn (goto-char next-button) (forward-line 0) (point))))
 
           ;; Neither the previous nor the next button exists. Simply delete the
           ;; current line.
           (t
-           (delete-region (point-at-bol) (point-at-eol)))))
+           (delete-region (line-beginning-position) (line-end-position)))))
        (if (equal (point-min) prev-project-pos)
            (goto-char next-project-pos)
          (goto-char prev-project-pos)))
@@ -717,7 +717,7 @@ PROJECT: Project Struct"
   (interactive)
   (save-excursion
     (goto-char (treemacs-project->position project))
-    (let* ((start (point-at-bol))
+    (let* ((start (line-beginning-position))
            (next  (treemacs--next-non-child-button (treemacs-project->position project)))
            (end   (if next
                       (-> next (treemacs-button-start) (previous-button) (treemacs-button-end))
@@ -794,7 +794,7 @@ PROJECT: Project Struct"
       (_
        (goto-char 0)
        (search-forward-regexp (rx-to-string `(seq bol ,line eol)))))
-    (setf treemacs--org-err-ov (make-overlay (point-at-eol) (point-at-eol)))
+    (setf treemacs--org-err-ov (make-overlay (line-end-position) (line-end-position)))
     (overlay-put treemacs--org-err-ov 'after-string
                  (concat (propertize " ← " 'face 'error) message))
     (add-hook 'after-change-functions #'treemacs--org-edit-remove-validation-msg nil :local)))

--- a/src/extra/treemacs-icons-dired.el
+++ b/src/extra/treemacs-icons-dired.el
@@ -106,7 +106,7 @@ This will make sure the icons' background colours will align with hl-line mode."
           (treemacs--evade-image)
           (unless (region-active-p)
             (let* ((last-pos treemacs--last-highlight)
-                   (curr-pos (next-single-char-property-change (point-at-bol) 'img-selected nil (point-at-eol)))
+                   (curr-pos (next-single-char-property-change (line-beginning-position) 'img-selected nil (line-end-position)))
                    (img-selected (get-text-property curr-pos 'img-selected)))
               (treemacs-with-writable-buffer
                (when (and last-pos (< last-pos (point-max)))


### PR DESCRIPTION
To reproduce, have emacs built with native compilation and notice the compilation logs. You can then open the offending file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.

```
Warning: ‘point-at-bol’ is an obsolete function (as of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
Warning: ‘point-at-eol’ is an obsolete function (as of 29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
```

Note: there is another warning:
```
Error: Eager macro-expansion failure: (error "‘buffer-local-value’ is an obsolete generalized variable.")
```

But I do not know how to tackle this one :cry: .