### PR TITLE
Support Python 3.6 in treemacs-single-file-git-status.py

### DIFF
--- a/src/scripts/treemacs-single-file-git-status.py
+++ b/src/scripts/treemacs-single-file-git-status.py
@@ -73,7 +73,7 @@ def main():
             propagate_state = "?"
             result_list.append((path, propagate_state))
             break
-        elif (changed_proc.wait() == 0 and changed_proc.stdout.read1() != b''):
+        elif (changed_proc.wait() == 0 and changed_proc.stdout.read1(1) != b''):
             result_list.append((path, "M"))
         else:
             result_list.append((path, "0"))


### PR DESCRIPTION
Thanks for a nice package!

I'm stuck on a system with Python 3.6 and got the problem described in #956.

The issue is that [io.BufferedReader.read1](https://docs.python.org/3.6/library/io.html#io.BufferedReader) needs an argument in Python 3.6, and `-1` is not supported. But if I understand the code correctly, it should be enough to read one byte, so I made it so locally and it seems to work fine for me. Perhaps the fix could be acceptable for treemacs master as well?