### PR TITLE
[Persp] Rename treemacs workspace when persp is renamed

### DIFF
--- a/src/extra/treemacs-magit.el
+++ b/src/extra/treemacs-magit.el
@@ -24,7 +24,7 @@
 ;;; Closing the gaps for filewatch- and git-modes in conjunction with magit.
 ;;; Specifically this package will hook into magit so as to artificially
 ;;; produce filewatch events for changes that treemacs would otherwise
-;;; not catch, nameley the committing and (un)staging of files.
+;;; not catch, namely the committing and (un)staging of files.
 
 ;;; Code:
 

--- a/src/extra/treemacs-mu4e.el
+++ b/src/extra/treemacs-mu4e.el
@@ -25,7 +25,7 @@
 ;; This package creates a thunderbird-inspired sidebar for mu4e using
 ;; treemacs' treelib api.
 ;;
-;; Some of mu's directoties are not part of a maildir hierarchy, but stand at the
+;; Some of mu's directories are not part of a maildir hierarchy, but stand at the
 ;; top alone.  Like in thunderbird, they are grouped in a fake "Local Folders" tree.
 ;; Since the top of this does not really exist it is sometimes necessary to make
 ;; the mapping towards the "true" maildir' folder, e.g. when displaying the maildir

--- a/src/extra/treemacs-persp.el
+++ b/src/extra/treemacs-persp.el
@@ -67,7 +67,7 @@ Will return \"No Perspective\" if no perspective is active."
   "Hook running after the perspective was switched.
 Will select a workspace for the now active perspective, creating it if
 necessary."
-  ;; runnig with a timer ensures that any other post-processing is finished after a perspective
+  ;; running with a timer ensures that any other post-processing is finished after a perspective
   ;; was run since commands like `spacemacs/helm-persp-switch-project' first create a perspective
   ;; and only afterwards select the file to display
   (run-with-timer
@@ -109,7 +109,7 @@ does not return anything the projects of the fallback workspace will be copied."
                       :path root-path
                       :path-status (treemacs--get-path-status root-path))))
        (-let [fallback-workspace (car treemacs--workspaces)]
-         ;; copy the projects instead of reusing them so we don't accidentially rename
+         ;; copy the projects instead of reusing them so we don't accidentally rename
          ;; a project in 2 workspaces
          (dolist (project (treemacs-workspace->projects fallback-workspace))
            (push (treemacs-project->create!

--- a/src/extra/treemacs-persp.el
+++ b/src/extra/treemacs-persp.el
@@ -55,13 +55,22 @@ Will return \"No Perspective\" if no perspective is active."
 (cl-defmethod treemacs-scope->setup ((_ (subclass treemacs-persp-scope)))
   "Persp-scope setup."
   (add-hook 'persp-activated-functions #'treemacs-persp--on-perspective-switch)
+  (add-hook 'persp-renamed-functions #'treemacs-persp--on-perspective-rename)
   (add-hook 'persp-before-kill-functions #'treemacs--on-scope-kill)
   (treemacs-persp--ensure-workspace-exists))
 
 (cl-defmethod treemacs-scope->cleanup ((_ (subclass treemacs-persp-scope)))
   "Persp-scope tear-down."
   (remove-hook 'persp-activated-functions #'treemacs-persp--on-perspective-switch)
+  (remove-hook 'persp-renamed-functions #'treemacs-persp--on-perspective-rename)
   (remove-hook 'persp-before-kill-functions #'treemacs--on-scope-kill))
+
+(defun treemacs-persp--on-perspective-rename (_perspective old-name new-name)
+  "Hook running after perspective was renamed.
+Will rename treemacs perspective workspace OLD-NAME to use NEW-NAME."
+  (treemacs-do-rename-workspace
+   (treemacs--find-workspace-by-name (treemacs-persp--format-workspace-name old-name))
+   (treemacs-persp--format-workspace-name new-name)))
 
 (defun treemacs-persp--on-perspective-switch (&rest _)
   "Hook running after the perspective was switched.
@@ -119,6 +128,10 @@ does not return anything the projects of the fallback workspace will be copied."
                  project-list))))
      (setf (treemacs-workspace->projects ws) (nreverse project-list))
      (treemacs-return ws))))
+
+(defun treemacs-persp--format-workspace-name (perspective-name)
+  "Format of the workspace name used for a perspective named PERSPECTIVE-NAME."
+  (format "Perspective %s" perspective-name))
 
 (provide 'treemacs-persp)
 

--- a/src/extra/treemacs-perspective.el
+++ b/src/extra/treemacs-perspective.el
@@ -72,7 +72,7 @@ Will return \"No Perspective\" if no perspective is active."
   "Hook running after the perspective was switched.
 Will select a workspace for the now active perspective, creating it if
 necessary."
-  ;; runnig with a timer ensures that any other post-processing is finished after a perspective
+  ;; running with a timer ensures that any other post-processing is finished after a perspective
   ;; was run since commands like `spacemacs/helm-persp-switch-project' first create a perspective
   ;; and only afterwards select the file to display
   (run-with-timer
@@ -114,7 +114,7 @@ does not return anything the projects of the fallback workspace will be copied."
                       :path root-path
                       :path-status (treemacs--get-path-status root-path))))
        (-let [fallback-workspace (car treemacs--workspaces)]
-         ;; copy the projects instead of reusing them so we don't accidentially rename
+         ;; copy the projects instead of reusing them so we don't accidentally rename
          ;; a project in 2 workspaces
          (dolist (project (treemacs-workspace->projects fallback-workspace))
            (push (treemacs-project->create!

--- a/src/extra/treemacs-projectile.el
+++ b/src/extra/treemacs-projectile.el
@@ -98,7 +98,7 @@ the current dir."
                 (--reject (treemacs-is-path it :in-workspace))
                 (-sort #'string<))]
       (if (null projects)
-          (list (vector "All Projectile projects are alread in the workspace" #'ignore))
+          (list (vector "All Projectile projects are already in the workspace" #'ignore))
         (--map (vector it (lambda () (interactive) (treemacs-add-project-to-workspace it))) projects)))))
 
 (add-to-list 'treemacs--find-user-project-functions #'treemacs--projectile-current-user-project-function)

--- a/src/extra/treemacs-tab-bar.el
+++ b/src/extra/treemacs-tab-bar.el
@@ -115,7 +115,7 @@ does not return anything the projects of the fallback workspace will be copied."
                       :path root-path
                       :path-status (treemacs--get-path-status root-path))))
        (-let [fallback-workspace (car treemacs--workspaces)]
-         ;; copy the projects instead of reusing them so we don't accidentially rename
+         ;; copy the projects instead of reusing them so we don't accidentally rename
          ;; a project in 2 workspaces
          (dolist (project (treemacs-workspace->projects fallback-workspace))
            (push (treemacs-project->create!


### PR DESCRIPTION
## Summary
My attempt to fix [issue 1002](https://github.com/Alexander-Miller/treemacs/issues/1002). I added logic to programmatically rename a treemacs workspace and then added hooks for persp-mode and perspective.el.

I also did some spelling fixes in other files. All the spelling fixes are in a separate commit for logical clarity.

## Callouts
- I've only tested the `treemacs-perspective--on-perspective-rename` function manually since I don't use `perspective.el`.
- There are more places where the rename function could be inserted to be used, but I left them alone for the time being as I don't know the treemacs codebase that well.
- Along with the previous point, I don't know if the rename function was written as efficiently as possible, so let me know if there are obvious improvements to be made.

## Other
Apologies for the multiple pull requests. I won't go into details about why that happened, but this one is finally in a state where it's showing the correct set of changes.