### PR TITLE
Handle unsupported images.

### DIFF
--- a/src/elisp/treemacs-icons.el
+++ b/src/elisp/treemacs-icons.el
@@ -206,7 +206,8 @@ Necessary since root icons are not rectangular."
     (inline-quote
      (let ((tui-icon ,fallback)
            (gui-icon
-            (if (treemacs--is-image-creation-impossible?)
+            (if (or (treemacs--is-image-creation-impossible?)
+                    (not (image-type-available-p (intern (treemacs--file-extension ,file)))))
                 ,fallback
               (let* ((img-selected   (treemacs--create-image ,file))
                      (img-unselected (copy-sequence img-selected)))


### PR DESCRIPTION
The recent update to use SVG images appear to be quite fragile, breaking a number of common use-cases including TUI usage that should have been filtered out elsewhere.

This change makes sure that if the image-type is not supported, the fallback is directly used.

This should solve issues encountered in #1017.