### PR TITLE
Fix treemacs-delete-other-windows

### DIFF
--- a/src/elisp/treemacs-interface.el
+++ b/src/elisp/treemacs-interface.el
@@ -560,7 +560,7 @@ also not be deleted."
       ;; that we shouldn't prevent from running, so we just restore treemacs instead of preventing
       ;; it from being deleted
       ;; 'no-delete-other-windows could be used instead, but it's only available for emacs 26
-      (when w
+      (when (and w (not (equal 'visible (treemacs-current-visibility))))
         (treemacs--select-not-visible-window)))))
 
 (defun treemacs-temp-resort-root (&optional sort-method)


### PR DESCRIPTION
Hi and thanks for the great package!

Currently `treemacs-delete-other-windows` calls `treemacs--select-not-visible-window`, with the assumption that the treemacs window is not visible anymore. The assumption can be false since `delete-window` doesn't delete treemacs in all setups (e.g. when `treemacs-display-in-side-window` is `t` and treemacs is in a side window). The result is that calling `treemacs-delete-other-windows` on the treemacs window splits the treemacs side window vertically. This PR fixes that.