### PR TITLE
[UI] Add current workspace name to doom-modeline

### DIFF
--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -226,9 +226,12 @@ Will be set by `treemacs--post-command'.")
               ((memq 'moody-mode-line-buffer-identification
                      (default-value 'mode-line-format))
                '(:eval (moody-tab " Treemacs " 10 'down)))
-              ((and (fboundp 'doom-modeline)
-                    (fboundp 'doom-modeline-def-modeline))
-               (doom-modeline-def-modeline 'treemacs '(bar " " major-mode))
+              ((fboundp 'doom-modeline)
+               (with-no-warnings
+                 (doom-modeline-def-segment treemacs
+                   "Display treemacs."
+                   (propertize (format " %s " (treemacs-workspace->name (treemacs-current-workspace)) )
+                               'face (doom-modeline-face 'doom-modeline-buffer-minor-mode))))
                (doom-modeline 'treemacs))
               (t
                '(:eval (format " Treemacs: %s"


### PR DESCRIPTION
Using the extra segment, the current workspace name will be shown on the doom-modeline. I have provided a screenshot to show how it looks. I have chosen for the minor-mode-face to make a difference between the major-mode (Treemacs) and the workspace name.

![IMG_1037](https://github.com/Alexander-Miller/treemacs/assets/12570668/038d8694-39a3-4f83-9ab4-648eaf641eb7)
