### PR TITLE
Show workspace name in doom-modeline

### DIFF
--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -226,10 +226,14 @@ Will be set by `treemacs--post-command'.")
               ((memq 'moody-mode-line-buffer-identification
                      (default-value 'mode-line-format))
                '(:eval (moody-tab " Treemacs " 10 'down)))
-              ((and (fboundp 'doom-modeline)
-                    (fboundp 'doom-modeline-def-modeline))
-               (doom-modeline-def-modeline 'treemacs '(bar " " major-mode) '())
-               (doom-modeline 'treemacs))
+              ((eval-and-compile (require 'doom-modeline nil 'noerror))
+               (with-no-warnings
+                 (doom-modeline-def-segment treemacs-workspace-name
+                   "Display treemacs."
+                   (propertize (format " %s " (treemacs-workspace->name (treemacs-current-workspace)))
+                               'face (doom-modeline-face 'doom-modeline-buffer-minor-mode)))
+                 (doom-modeline-def-modeline 'treemacs '(bar " " major-mode) '(treemacs-workspace-name))
+                 (doom-modeline 'treemacs)))
               (t
                '(:eval (format " Treemacs: %s"
                                (treemacs-workspace->name (treemacs-current-workspace))))))))


### PR DESCRIPTION
Fixes #1047 and #1048