### PR TITLE
[UI] Revert changes to show current workspace name for doom-modeline

### DIFF
--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -226,14 +226,10 @@ Will be set by `treemacs--post-command'.")
               ((memq 'moody-mode-line-buffer-identification
                      (default-value 'mode-line-format))
                '(:eval (moody-tab " Treemacs " 10 'down)))
-              ((fboundp 'doom-modeline)
-               (with-no-warnings
-                 (doom-modeline-def-segment treemacs
-                   "Display treemacs."
-                   (propertize (format " %s " (treemacs-workspace->name (treemacs-current-workspace)))
-                               'face (doom-modeline-face 'doom-modeline-buffer-minor-mode)))
-                 (doom-modeline-def-modeline 'treemacs '(bar " " major-mode) '(treemacs))
-                 (doom-modeline 'treemacs)))
+              ((and (fboundp 'doom-modeline)
+                    (fboundp 'doom-modeline-def-modeline))
+               (doom-modeline-def-modeline 'treemacs '(bar " " major-mode) '())
+               (doom-modeline 'treemacs))
               (t
                '(:eval (format " Treemacs: %s"
                                (treemacs-workspace->name (treemacs-current-workspace))))))))


### PR DESCRIPTION
Revert until #1049 has a working solution that also works with native compilation