### PR TITLE
[Treelib] Let extensions control help-echo

### DIFF
--- a/src/elisp/treemacs-treelib.el
+++ b/src/elisp/treemacs-treelib.el
@@ -666,7 +666,6 @@ LABEL: String"
               #'propertize ,label
               'button '(t)
               'category t
-              'help-echo nil
               :custom t
               :state ,state
               :parent ,parent


### PR DESCRIPTION
The same as was done for extensions in 0a3d2bd67cfb56468fbeea1e0be86436c049e931