### PR TITLE
Fix #1073

### DIFF
--- a/src/elisp/treemacs-treelib.el
+++ b/src/elisp/treemacs-treelib.el
@@ -370,8 +370,9 @@ argument."
           :on-expand       (lambda (&optional btn )     "" (ignore btn) ,on-expand)
           :on-collapse     (lambda (&optional btn )     "" (ignore btn) ,on-collapse)))
 
-       (treemacs-define-doubleclick-action ',closed-state ,(or double-click-action '#'ignore))
-       (treemacs-define-doubleclick-action ',open-state ,(or double-click-action '#'ignore))
+       (with-eval-after-load 'treemacs-mouse-interface
+         (treemacs-define-doubleclick-action ',closed-state ,(or double-click-action '#'ignore))
+         (treemacs-define-doubleclick-action ',open-state ,(or double-click-action '#'ignore)))
 
        (treemacs-define-TAB-action
         ',closed-state


### PR DESCRIPTION
Set the double click actions only after the optional mouse interface extension has been loaded.