### PR TITLE
Strip filename after splitting a line

### DIFF
--- a/src/scripts/treemacs-git-status.py
+++ b/src/scripts/treemacs-git-status.py
@@ -69,6 +69,7 @@ def main():
         # reduce the state to a single-letter-string
         state = state[0:1]
 
+        filename = filename.strip()
         # sometimes git outputs quoted filesnames
         if filename.startswith(b'"'):
             filename = filename[1:-1]


### PR DESCRIPTION
Prevents incorrect quoting of filenames.

Resolves https://github.com/Alexander-Miller/treemacs/issues/1084.