### PR TITLE
Ignoring nonstandard backup files

### DIFF
--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -1041,7 +1041,7 @@ Will return t when FILE
      (let ((last (aref ,file (1- (length ,file)))))
        (or (string-prefix-p ".#" ,file)
            (and (eq ?# last) (eq ?# (aref ,file 0)))
-           (eq ?~ last)
+           (backup-file-name-p ,file)
            (string-equal ,file ".")
            (string-equal ,file "..")
            (and treemacs-hide-dot-git-directory


### PR DESCRIPTION
`treemacs--std-ignore-file-predicate` has a long list of checks to determine whether a file should be ignored. One of them is to see whether it ends in `~`, i.e., it's a backup file.

Emacs allows people to customize backup file names, and `treemacs--std-ignore-file-predicate`'s test fails when someone uses a nonstandard extension like `.bak` for backup files. Thankfully, Emacs includes the `backup-file-name-p` function to test whether something is a backup filename. It's a simple matter of replacing `(eq ?~ last)` with `(backup-file-name-p ,file)`.