### PR TITLE
[Tab Bar] Correct method for getting current tab

### DIFF
--- a/src/extra/treemacs-tab-bar.el
+++ b/src/extra/treemacs-tab-bar.el
@@ -41,8 +41,8 @@
 (cl-defmethod treemacs-scope->current-scope ((_ (subclass treemacs-tab-bar-scope)))
   "Get the current tab as scope.
 Return symbol `none' unless variable `tab-bar-mode' is non-nil."
-(if tab-bar-mode
-      (cdr (assq 'name (tab-bar-get-buffer-tab nil)))
+  (if tab-bar-mode
+      (cdr (assq 'name (tab-bar--current-tab)))
     'none))
 
 (cl-defmethod treemacs-scope->current-scope-name ((_ (subclass treemacs-tab-bar-scope)) tab)


### PR DESCRIPTION
If a tab's selected buffer is the Treemacs buffer when switching away from a tab and back to that tab, the Treemacs buffer will temporarily not be considered part in the current tab. My original technique for getting the current tab was either always wrong or based on the best we could do at the time with the APIs available. This method of getting the current tab seems to work consistently.