### PR TITLE
add: Icon for ClojureDart filetype

### DIFF
--- a/src/elisp/treemacs-icons.el
+++ b/src/elisp/treemacs-icons.el
@@ -301,7 +301,7 @@ Necessary since root icons are not rectangular."
     (treemacs-create-icon :file "asciidoc.png"      :extensions ("adoc" "asciidoc"))
     (treemacs-create-icon :file "rust.png"          :extensions ("rs"))
     (treemacs-create-icon :file "image.png"         :extensions ("jpg" "jpeg" "bmp" "svg" "png" "xpm" "gif"))
-    (treemacs-create-icon :file "clojure.png"       :extensions ("clj" "cljs" "cljc" "edn"))
+    (treemacs-create-icon :file "clojure.png"       :extensions ("clj" "cljs" "cljc" "cljd" "edn"))
     (treemacs-create-icon :file "ts.png"            :extensions ("ts" "tsx"))
     (treemacs-create-icon :file "vue.png"           :extensions ("vue"))
     (treemacs-create-icon :file "css.png"           :extensions ("css" "rasi"))
@@ -575,7 +575,7 @@ be assigned which treemacs icon, for example
                icon))))
 
 (treemacs-only-during-init
-  (treemacs-load-theme "Default"))
+ (treemacs-load-theme "Default"))
 
 (provide 'treemacs-icons)
 


### PR DESCRIPTION
Why?:
- ClojureDart is a new and coming dialect of Clojure. Thus its files should have the same icon as other Clojure files.

This change addresses the need by:
- Add "cljd" as additional Clojure file extension