### PR TITLE
[Git] Unquote `treemacs-git-executable` variable

### DIFF
--- a/src/elisp/treemacs-async.el
+++ b/src/elisp/treemacs-async.el
@@ -397,7 +397,7 @@ run because the git cache has yet to be filled."
   (pfuture-callback `(,treemacs-python-executable
                       "-O"
                       ,treemacs--find-ignored-files.py
-                      treemacs-git-executable
+                      ,treemacs-git-executable
                       ,@path)
     :on-error (ignore)
     :on-success


### PR DESCRIPTION
The change is introduced in commit ac3f0706bf6248b7321da683438efdcc6bce3e4c.