### PR TITLE
fix: don't set window parameters if treemacs buff has no window

### DIFF
--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -374,7 +374,8 @@ Will simply return `treemacs--eldoc-msg'."
     (treemacs--on-window-config-change))
   ;; set the parameter immediately so it can take effect when `treemacs' is called programatically
   ;; alongside other window layout chaning commands that might delete it again
-  (set-window-parameter (selected-window) 'no-delete-other-windows treemacs-no-delete-other-windows)
+  (if (get-buffer-window (current-buffer))
+      (set-window-parameter (selected-window) 'no-delete-other-windows treemacs-no-delete-other-windows))
 
   (face-remap-add-relative 'default 'treemacs-window-background-face)
   (face-remap-add-relative 'fringe  'treemacs-window-background-face)


### PR DESCRIPTION
This fixes bug #1149 on the treemacs issue list.  This occurs when treemacs-mode is called on a buffer that doesn't have a window.  This occurs in the lsp hooks when a lsp event occurs, and the lsp buffer in question (in my case, the error list) doesn't have a window.  The result is whatever window that was selected gets
'no-delete-other-windows set on it.  Afterwards C-x 1 doesn't work as expected.

https://github.com/Alexander-Miller/treemacs/issues/1149