### PR TITLE
Fix `treemacs-git-commit-diff-mode` when a non-English locale is set

### DIFF
--- a/src/scripts/treemacs-count-mail.py
+++ b/src/scripts/treemacs-count-mail.py
@@ -32,7 +32,8 @@ def main():
                        shell=True,
                        stdout=PIPE,
                        bufsize=100,
-                       encoding='utf-8'
+                       encoding='utf-8',
+                       env={"LC_ALL": "C"}
                     ).communicate()[0][:-1]
 
         if unread == "0":

--- a/src/scripts/treemacs-find-ignored-files.py
+++ b/src/scripts/treemacs-find-ignored-files.py
@@ -37,7 +37,7 @@ def main():
 
     for root in roots:
         if exists(root + "/.git"):
-            proc = Popen(GIT_CMD, shell=True, stdout=PIPE, bufsize=100, cwd=root)
+            proc = Popen(GIT_CMD, shell=True, stdout=PIPE, bufsize=100, cwd=root, env={"LC_ALL": "C"})
             procs.append((root, proc))
 
     STDOUT.write(b"(")

--- a/src/scripts/treemacs-git-commit-diff.py
+++ b/src/scripts/treemacs-git-commit-diff.py
@@ -5,7 +5,7 @@ GIT_BIN = sys.argv[1]
 STATUS_CMD = "{} status -sb".format(GIT_BIN)
 
 def main():
-    proc = Popen(STATUS_CMD, shell=True, stdout=PIPE, bufsize=100)
+    proc = Popen(STATUS_CMD, shell=True, stdout=PIPE, bufsize=100, env={"LC_ALL": "C"})
 
     if (proc.wait() != 0):
         sys.exit(2)

--- a/src/scripts/treemacs-git-status.py
+++ b/src/scripts/treemacs-git-status.py
@@ -1,5 +1,5 @@
 from subprocess import Popen, PIPE
-from os import listdir, environ
+from os import listdir
 from os.path import isdir, islink
 from posixpath import join
 import sys
@@ -54,8 +54,7 @@ def find_recursive_entries(path, state):
 def main():
     global output, ht_size
     # Don't lock Git when updating status.
-    environ["GIT_OPTIONAL_LOCKS"] = "0"
-    proc = Popen(GIT_CMD, shell=True, stdout=PIPE, bufsize=100)
+    proc = Popen(GIT_CMD, shell=True, stdout=PIPE, bufsize=100, env={"LC_ALL": "C", "GIT_OPTIONAL_LOCKS": "0"})
     dirs_added = {}
 
     for item in proc.stdout:

--- a/src/scripts/treemacs-single-file-git-status.py
+++ b/src/scripts/treemacs-single-file-git-status.py
@@ -90,14 +90,14 @@ def main():
     print(elisp_alist)
 
 def add_git_processes(status_listings, path):
-    ignored_proc = Popen(IS_IGNORED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL)
-    tracked_proc = Popen(IS_TRACKED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL)
-    changed_proc = Popen(IS_CHANGED_CMD + path, shell=True, stdout=PIPE,    stderr=DEVNULL)
+    ignored_proc = Popen(IS_IGNORED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL, env={"LC_ALL": "C"})
+    tracked_proc = Popen(IS_TRACKED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL, env={"LC_ALL": "C"})
+    changed_proc = Popen(IS_CHANGED_CMD + path, shell=True, stdout=PIPE,    stderr=DEVNULL, env={"LC_ALL": "C"})
 
     status_listings.append((path, ignored_proc, tracked_proc, changed_proc))
 
 def determine_file_git_state():
-    proc = Popen(FILE_STATE_CMD + FILE, shell=True, stdout=PIPE, stderr=DEVNULL)
+    proc = Popen(FILE_STATE_CMD + FILE, shell=True, stdout=PIPE, stderr=DEVNULL, env={"LC_ALL": "C"})
     line = proc.stdout.readline()
     if line:
         state = line.lstrip().split(b" ")[0]


### PR DESCRIPTION
Some features like `treemacs-git-commit-diff-mode` are broken when a non-English locale is set.
This is due to the parsing logic contained in the Python scripts which expect `git` commands output to be in English.

Ex.:
```console
$ locale
LANG=fr_FR.utf8
LC_CTYPE="fr_FR.utf8"
LC_NUMERIC="fr_FR.utf8"
LC_TIME="fr_FR.utf8"
LC_COLLATE="fr_FR.utf8"
LC_MONETARY="fr_FR.utf8"
LC_MESSAGES="fr_FR.utf8"
LC_PAPER="fr_FR.utf8"
LC_NAME="fr_FR.utf8"
LC_ADDRESS="fr_FR.utf8"
LC_TELEPHONE="fr_FR.utf8"
LC_MEASUREMENT="fr_FR.utf8"
LC_IDENTIFICATION="fr_FR.utf8"
LC_ALL=

$ git status -sb
## master...origin/master [devant 11]
…

$ python ~/.config/emacs/elpa/treemacs-20250423.2024/treemacs-git-commit-diff.py git .
#(" ↑0 ↓0" 0 4 (face treemacs-git-commit-diff-face))

$ LC_ALL=C python ~/.config/emacs/elpa/treemacs-20250423.2024/treemacs-git-commit-diff.py git .
#(" ↑11" 0 4 (face treemacs-git-commit-diff-face))

$ python ~/.config/emacs/elpa/treemacs-20250423.2024/treemacs-find-ignored-files.py git .
(".""./Supprimerait #git#"".""./Supprimerait .dir-locals.el~"".""./Supprimerait ansible-libvirt.cfg~"".""./Supprimerait archlinux.yml~"…

$ LC_ALL=C python ~/.config/emacs/elpa/treemacs-20250423.2024/treemacs-find-ignored-files.py git .
(".""./#git#"".""./.dir-locals.el~"".""./ansible-libvirt.cfg~"".""./archlinux.yml~"…
```

`treemacs-git-commit-diff.py` and `treemacs-find-ignored-files.py` are two examples of scripts that are not working properly when a non-English locale is set.
`git` commands executed with `--procelain` shouldn’t be affected by this issue. But for consistency, I decided to explicitly reset the locale for all the commands run by all the Python scripts.

(*) “devant” is the french translation of [“ahead”](https://github.com/Alexander-Miller/treemacs/blob/820b09db106a48db76d95e3a266d1e67ae1b6bdb/src/scripts/treemacs-git-commit-diff.py#L31) and “Supprimerait” is the french translation of [“Would remove”](https://github.com/Alexander-Miller/treemacs/blob/820b09db106a48db76d95e3a266d1e67ae1b6bdb/src/scripts/treemacs-find-ignored-files.py#L19).