### PR TITLE
[Compatibility] Handle new persp-mode hook signature

### DIFF
--- a/src/elisp/treemacs-compatibility.el
+++ b/src/elisp/treemacs-compatibility.el
@@ -108,7 +108,7 @@ to split it."
        (select-window (next-window))))))
 
 (with-eval-after-load 'persp-mode
-  (defun treemacs--remove-treemacs-window-in-new-frames (persp-activated-for)
+  (defun treemacs--remove-treemacs-window-in-new-frames (persp-activated-for &rest _)
     (when (eq persp-activated-for 'frame)
       (-when-let (w (--first (treemacs-is-treemacs-window? it)
                              (window-list)))


### PR DESCRIPTION
persp-mode now passes 3 arguments to hooks run on perspective activation. Ignore the new arguments that we don't care about so that we can support old and new versions alike. Fixes #1165.

---

Added a commit like what was discussed in #1165, since this is causing me a lot of pain in my day-to-day.