### PR TITLE
[Git] Fix loss of environment propagation in Python scripts.

### DIFF
--- a/src/scripts/treemacs-count-mail.py
+++ b/src/scripts/treemacs-count-mail.py
@@ -1,5 +1,6 @@
 from subprocess import Popen, PIPE
 import sys
+from os import environ
 
 # Command line arguments are a list of maildirs.
 # The output is a list of items in the form '((P1 A1) (P2 A2))' where P is the node path for a maildir
@@ -28,12 +29,12 @@ def main():
             if mu_dir == "/":
                 continue
 
+        environ["LC_ALL"] = "C"
         unread = Popen(UNREAD_CMD.format(mu_dir.replace(" ", "\ ")),
                        shell=True,
                        stdout=PIPE,
                        bufsize=100,
-                       encoding='utf-8',
-                       env={"LC_ALL": "C"}
+                       encoding='utf-8'
                     ).communicate()[0][:-1]
 
         if unread == "0":

--- a/src/scripts/treemacs-find-ignored-files.py
+++ b/src/scripts/treemacs-find-ignored-files.py
@@ -1,5 +1,6 @@
 from subprocess import Popen, PIPE
 from os.path import exists
+from os import environ
 import sys
 
 GIT_BIN = sys.argv[1]
@@ -37,7 +38,8 @@ def main():
 
     for root in roots:
         if exists(root + "/.git"):
-            proc = Popen(GIT_CMD, shell=True, stdout=PIPE, bufsize=100, cwd=root, env={"LC_ALL": "C"})
+            environ["LC_ALL"] = "C"
+            proc = Popen(GIT_CMD, shell=True, stdout=PIPE, bufsize=100, cwd=root)
             procs.append((root, proc))
 
     STDOUT.write(b"(")

--- a/src/scripts/treemacs-git-commit-diff.py
+++ b/src/scripts/treemacs-git-commit-diff.py
@@ -1,11 +1,13 @@
 from subprocess import Popen, PIPE
 import sys
+from os import environ
 
 GIT_BIN = sys.argv[1]
 STATUS_CMD = "{} status -sb".format(GIT_BIN)
 
 def main():
-    proc = Popen(STATUS_CMD, shell=True, stdout=PIPE, bufsize=100, env={"LC_ALL": "C"})
+    environ["LC_ALL"] = "C"
+    proc = Popen(STATUS_CMD, shell=True, stdout=PIPE, bufsize=100)
 
     if (proc.wait() != 0):
         sys.exit(2)

--- a/src/scripts/treemacs-git-status.py
+++ b/src/scripts/treemacs-git-status.py
@@ -1,5 +1,5 @@
 from subprocess import Popen, PIPE
-from os import listdir
+from os import listdir, environ
 from os.path import isdir, islink
 from posixpath import join
 import sys
@@ -54,7 +54,9 @@ def find_recursive_entries(path, state):
 def main():
     global output, ht_size
     # Don't lock Git when updating status.
-    proc = Popen(GIT_CMD, shell=True, stdout=PIPE, bufsize=100, env={"LC_ALL": "C", "GIT_OPTIONAL_LOCKS": "0"})
+    environ["LC_ALL"] = "C"
+    environ["GIT_OPTIONAL_LOCKS"] = "0"
+    proc = Popen(GIT_CMD, shell=True, stdout=PIPE, bufsize=100)
     dirs_added = {}
 
     for item in proc.stdout:

--- a/src/scripts/treemacs-single-file-git-status.py
+++ b/src/scripts/treemacs-single-file-git-status.py
@@ -1,6 +1,7 @@
 from subprocess import run, Popen, PIPE, DEVNULL, check_output
 import sys
 import os
+from os import environ
 
 # There are 3+ command line arguments:
 # 1) the file to update
@@ -90,14 +91,16 @@ def main():
     print(elisp_alist)
 
 def add_git_processes(status_listings, path):
-    ignored_proc = Popen(IS_IGNORED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL, env={"LC_ALL": "C"})
-    tracked_proc = Popen(IS_TRACKED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL, env={"LC_ALL": "C"})
-    changed_proc = Popen(IS_CHANGED_CMD + path, shell=True, stdout=PIPE,    stderr=DEVNULL, env={"LC_ALL": "C"})
+    environ["LC_ALL"] = "C"
+    ignored_proc = Popen(IS_IGNORED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL)
+    tracked_proc = Popen(IS_TRACKED_CMD + path, shell=True, stdout=DEVNULL, stderr=DEVNULL)
+    changed_proc = Popen(IS_CHANGED_CMD + path, shell=True, stdout=PIPE,    stderr=DEVNULL)
 
     status_listings.append((path, ignored_proc, tracked_proc, changed_proc))
 
 def determine_file_git_state():
-    proc = Popen(FILE_STATE_CMD + FILE, shell=True, stdout=PIPE, stderr=DEVNULL, env={"LC_ALL": "C"})
+    environ["LC_ALL"] = "C"
+    proc = Popen(FILE_STATE_CMD + FILE, shell=True, stdout=PIPE, stderr=DEVNULL)
     line = proc.stdout.readline()
     if line:
         state = line.lstrip().split(b" ")[0]


### PR DESCRIPTION
As described in this issue: https://github.com/Alexander-Miller/treemacs/issues/1172 git calls have started failing on systems like NixOs and Guix.

This started with this commit: https://github.com/Alexander-Miller/treemacs/commit/2dd6d86a32eaea3b90389e260307e7606dcd920a

The commit explicitly set the subprocess environment just to have the value: `"LC_ALL": "C"`. This prevents systems like NixOs and Guix from passing shell environment variables to allow 'git' to be found in their stores. 

The fix is to append  `"LC_ALL": "C"` to the environment, rather than recreating a new env.

I did a basic test after to confirm that Emacs now launches with Treemacs by dropping in the modified scripts.