### PR TITLE
Fix treemacs-tag-follow-mode in gfm-mode

### DIFF
--- a/src/elisp/treemacs-tag-follow-mode.el
+++ b/src/elisp/treemacs-tag-follow-mode.el
@@ -87,7 +87,7 @@ or nesting depth."
            ;; in org mode buffers the first item may not be a cons since its position
            ;; is still stored as a text property
            (semantic? (and (consp first) (overlayp (cdr first))))
-           (compare-func (if (memq major-mode '(markdown-mode adoc-mode))
+           (compare-func (if (derived-mode-p '(markdown-mode adoc-mode))
                              #'treemacs--compare-markdown-tag-paths
                            #'treemacs--compare-tag-paths)))
       (cond


### PR DESCRIPTION
In gfm-mode, which is a derived mode from markdown-mode, treemacs-tag-follow-mode fails with the following error message.

```
[Treemacs] Encountered error while following tag at point: (wrong-type-argument markerp 150)
```

The problem is in treemacs--flatten&sort-imenu-index that chooses a compare function not suitable for the mode.