### PR TITLE
[Git] Fix annotation lookup for collapsed directories

### DIFF
--- a/src/elisp/treemacs-annotations.el
+++ b/src/elisp/treemacs-annotations.el
@@ -237,7 +237,7 @@ GIT-FUTURE: Pfuture"
       (save-excursion
         (treemacs-with-writable-buffer
          (let* ((depth (1+ (treemacs-button-get btn :depth)))
-                (git-info (or (ht-get treemacs--git-cache (treemacs-button-get btn :key))
+                (git-info (or (ht-get treemacs--git-cache path)
                               treemacs--empty-table)))
            ;; the depth check ensures that we only iterate over the nodes that
            ;; are below parent-btn and stop when we've moved on to nodes that


### PR DESCRIPTION
## Summary

- `treemacs--apply-annotations-deferred` used the parent button's `:key` to look up the git cache, but the cache is keyed by `:path` (via the `root`/`path` parameter)
- For collapsed/flattened directories, `:key` retains the original path while `:path` is updated to the deep path by `treemacs--flatten-dirs`, causing the lookup to miss
- All child nodes are left with `treemacs-git-unmodified-face` regardless of their actual git status
- Fix: use the `path` parameter directly, which is already the correct cache key

## Reproducing

1. Have a directory structure where treemacs collapses directories (e.g., `src/graph/` where `src` contains only `graph`)
2. `git add` a new file under the collapsed path (so it has index-only status `A`)
3. Expand the collapsed directory in treemacs — the file shows as `treemacs-git-unmodified-face` instead of `treemacs-git-added-face`
4. Verify the cache is correct: `(ht-get (ht-get treemacs--git-cache "<parent-dir>") "<file-path>")` returns the right face
5. Verify annotations are never created: `(treemacs-get-annotation "<file-path>")` returns `nil`

Affects all git modes (simple, extended, deferred) equally since the timer runs unconditionally.