### PR TITLE
[Git] Add git-status-indicator-mode: show status letters in margin

### DIFF
--- a/src/elisp/treemacs-annotations.el
+++ b/src/elisp/treemacs-annotations.el
@@ -39,6 +39,11 @@
 
 (defconst treemacs--annotation-store (make-hash-table :size 200 :test 'equal))
 
+(defvar treemacs--after-annotation-applied nil
+  "Optional function called after an annotation is applied to a node.
+Called with BTN and GIT-FACE as arguments.  Used by
+`treemacs-git-status-indicator-mode' to place margin indicators.")
+
 ;; TODO(2022/02/23): clear on file delete
 
 (cl-defstruct (treemacs-annotation
@@ -309,7 +314,11 @@ GIT-FACE is taken from the latest git cache, or nil if it's not known."
               new-face-value))
 
            ;; Suffix
-           (when suffix-value (insert suffix-value))))))))
+           (when suffix-value (insert suffix-value))))
+
+       ;; Post-annotation hook (used by git-status-indicator-mode)
+       (when treemacs--after-annotation-applied
+         (funcall treemacs--after-annotation-applied ,btn ,git-face))))))
 
 (defun treemacs-apply-single-annotation (path)
   "Apply annotations for a single node at given PATH in all treemacs buffers."

--- a/src/elisp/treemacs-git-status-indicator.el
+++ b/src/elisp/treemacs-git-status-indicator.el
@@ -1,0 +1,220 @@
+;;; treemacs-git-status-indicator.el --- Show git status letters in the margin -*- lexical-binding: t -*-
+
+;; Copyright (C) 2024 Alexander Miller
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Minor mode to display git status indicator letters (M, A, ?, !, U, R)
+;; in the margin of the treemacs buffer.
+
+;; NOTE: This module is lazy-loaded.
+
+;;; Code:
+
+(require 'ht)
+(require 'dash)
+(require 'treemacs-core-utils)
+(require 'treemacs-annotations)
+(require 'treemacs-async)
+
+(eval-when-compile
+  (require 'treemacs-macros))
+
+(defvar treemacs--after-annotation-applied)
+(defvar treemacs-git-status-indicator-mode)
+
+(defcustom treemacs-git-status-indicator-position 'left
+  "Which margin to display git status indicator letters in.
+Can be `left' or `right'."
+  :type '(choice (const :tag "Left margin"  left)
+                 (const :tag "Right margin" right))
+  :group 'treemacs-git)
+
+(defconst treemacs--git-indicator-face-letter-alist
+  '((treemacs-git-modified-face  . "M")
+    (treemacs-git-conflict-face  . "U")
+    (treemacs-git-untracked-face . "?")
+    (treemacs-git-ignored-face   . "!")
+    (treemacs-git-added-face     . "A")
+    (treemacs-git-renamed-face   . "R"))
+  "Alist mapping git face symbols to single-letter status indicators.")
+
+(defvar-local treemacs--git-indicator-prev-hl-ov nil
+  "The indicator overlay that currently has the hl-line face applied.")
+
+(defvar treemacs--git-indicator-bulk-applying nil
+  "Non-nil while `treemacs--git-indicator-apply-to-buffer' is running.")
+
+(defun treemacs--git-indicator-margin-spec (str)
+  "Build a margin display spec for STR."
+  (let ((margin-side (if (eq treemacs-git-status-indicator-position 'right)
+                         'right-margin
+                       'left-margin)))
+    (propertize " " 'display `((margin ,margin-side) ,str))))
+
+(defun treemacs--git-indicator-update (_btn git-face)
+  "Update the margin indicator for the current node based on GIT-FACE.
+Called as `treemacs--after-annotation-applied' after each node's
+annotation is applied.  Point is expected to be on the node's line.
+
+_BTN: Button (unused, point is already positioned)
+GIT-FACE: Face"
+  (let* ((letter (alist-get git-face treemacs--git-indicator-face-letter-alist))
+         (bol (line-beginning-position))
+         (eol (line-end-position))
+         ;; always display something — a space when no status — so that
+         ;; hl-line highlighting extends into the margin on every node
+         (str (or letter " ")))
+    ;; remove ALL existing indicator overlays on this line
+    (dolist (ov (overlays-in bol eol))
+      (when (overlay-get ov 'treemacs-git-indicator)
+        (delete-overlay ov)))
+    ;; place indicator overlay
+    ;; the git face goes on the OVERLAY's face property (not the string)
+    ;; so it applies to the before-string and can be swapped by hl-line
+    (let ((ov (make-overlay bol (1+ bol) nil t))
+          (on-hl-line (and (not treemacs--git-indicator-bulk-applying)
+                           (boundp 'hl-line-overlay)
+                           hl-line-overlay
+                           (overlay-buffer hl-line-overlay)
+                           (= (overlay-start hl-line-overlay) bol))))
+      (overlay-put ov 'before-string (treemacs--git-indicator-margin-spec str))
+      (overlay-put ov 'evaporate t)
+      (overlay-put ov 'treemacs-git-indicator t)
+      (overlay-put ov 'treemacs-git-face git-face)
+      ;; if this line is currently highlighted by hl-line, apply the
+      ;; composite face immediately — hl-line-highlight won't re-run
+      ;; since the cursor didn't move
+      (if on-hl-line
+          (progn
+            (overlay-put ov 'face (if git-face
+                                      (list 'hl-line git-face)
+                                    'hl-line))
+            (setq treemacs--git-indicator-prev-hl-ov ov))
+        (overlay-put ov 'face git-face)))))
+
+(defun treemacs--git-indicator-hl-update ()
+  "Update indicator faces when hl-line moves.
+Restores the previous line's indicator to its normal git face and applies
+the hl-line face to the current line's indicator, mirroring how hl-line
+treats filename text: hl-line attributes take priority, git face fills in
+the rest."
+  (when treemacs-git-status-indicator-mode
+    ;; restore previous highlighted overlay to its normal git face
+    (when (and treemacs--git-indicator-prev-hl-ov
+               (overlay-buffer treemacs--git-indicator-prev-hl-ov))
+      (overlay-put treemacs--git-indicator-prev-hl-ov
+                   'face
+                   (overlay-get treemacs--git-indicator-prev-hl-ov 'treemacs-git-face)))
+    ;; apply hl-line face to current line's indicator
+    ;; use 'hl-line face (buffer-locally remapped to treemacs-hl-line-face)
+    ;; with git-face as fallback — same merge as hl-line overlay over text property
+    (setq treemacs--git-indicator-prev-hl-ov nil)
+    (dolist (ov (overlays-at (line-beginning-position)))
+      (when (overlay-get ov 'treemacs-git-indicator)
+        (-let [git-face (overlay-get ov 'treemacs-git-face)]
+          (overlay-put ov 'face (if git-face
+                                    (list 'hl-line git-face)
+                                  'hl-line))
+          (setq treemacs--git-indicator-prev-hl-ov ov))))))
+
+(defun treemacs--git-indicator-setup-buffer ()
+  "Set the margin width in the current treemacs buffer.
+Uses `treemacs-git-status-indicator-position' to decide which margin."
+  (if (eq treemacs-git-status-indicator-position 'right)
+      (progn
+        (setq right-margin-width 2 left-margin-width 0)
+        ;; default: text | right-margin | right-fringe
+        ;; we want: text | right-fringe  | right-margin
+        (setq fringes-outside-margins nil))
+    (setq left-margin-width 2 right-margin-width 0)
+    ;; default: left-margin | left-fringe | text
+    ;; we want: left-fringe | left-margin | text
+    (setq fringes-outside-margins t))
+  (advice-add #'hl-line-highlight :after #'treemacs--git-indicator-hl-update)
+  (when (get-buffer-window (current-buffer))
+    (set-window-buffer (get-buffer-window (current-buffer))
+                       (current-buffer))))
+
+(defun treemacs--git-indicator-apply-to-buffer ()
+  "Apply git status indicators to all visible nodes in the current buffer."
+  (let ((treemacs--git-indicator-bulk-applying t))
+    (treemacs-with-writable-buffer
+     (save-excursion
+       (goto-char (point-min))
+       (let ((btn (point)))
+         (while (setf btn (next-button btn))
+           (let* ((path (treemacs-button-get btn :path))
+                  (git-cache
+                   (->> path
+                        (treemacs--parent-dir)
+                        (ht-get treemacs--git-cache)))
+                  (git-face (and git-cache (ht-get git-cache path))))
+             (goto-char btn)
+             (treemacs--git-indicator-update btn git-face))))))))
+
+(defun treemacs--enable-git-status-indicator-mode ()
+  "Setup for `treemacs-git-status-indicator-mode'."
+  (setf treemacs--after-annotation-applied #'treemacs--git-indicator-update)
+  (add-hook 'treemacs-mode-hook #'treemacs--git-indicator-setup-buffer)
+  (treemacs-run-in-all-derived-buffers
+   (treemacs--git-indicator-setup-buffer)
+   (treemacs--git-indicator-apply-to-buffer)))
+
+(defun treemacs--disable-git-status-indicator-mode ()
+  "Tear-down for `treemacs-git-status-indicator-mode'."
+  (setf treemacs--after-annotation-applied nil)
+  (remove-hook 'treemacs-mode-hook #'treemacs--git-indicator-setup-buffer)
+  (treemacs-run-in-all-derived-buffers
+   (advice-remove #'hl-line-highlight #'treemacs--git-indicator-hl-update)
+   (remove-overlays (point-min) (point-max) 'treemacs-git-indicator t)
+   (setq treemacs--git-indicator-prev-hl-ov nil)
+   (setq left-margin-width 0 right-margin-width 0 fringes-outside-margins nil)
+   (when (get-buffer-window (current-buffer))
+     (set-window-buffer (get-buffer-window (current-buffer))
+                        (current-buffer)))))
+
+;;;###autoload
+(define-minor-mode treemacs-git-status-indicator-mode
+  "Minor mode to display git status letters in the margin.
+
+When enabled a single-letter indicator will appear in the margin next to each
+file or directory that has a git status:
+
+  M - modified
+  A - added
+  ? - untracked
+  ! - ignored
+  U - conflict (unmerged)
+  R - renamed
+
+The indicator is colored with the same face as the filename and responds to
+hl-line highlighting.
+
+Which margin is used is controlled by `treemacs-git-status-indicator-position'.
+
+Requires `treemacs-git-mode' to be active for git status information."
+  :init-value nil
+  :global     t
+  :lighter    nil
+  :group      'treemacs-git
+  (if treemacs-git-status-indicator-mode
+      (treemacs--enable-git-status-indicator-mode)
+    (treemacs--disable-git-status-indicator-mode)))
+
+(provide 'treemacs-git-status-indicator)
+
+;;; treemacs-git-status-indicator.el ends here

--- a/src/elisp/treemacs-hydras.el
+++ b/src/elisp/treemacs-hydras.el
@@ -140,6 +140,7 @@ find the key a command is bound to it will show a blank instead."
              (key-indent-guide   (treemacs--find-keybind #'treemacs-indent-guide-mode))
              (key-show-gitignore (treemacs--find-keybind #'treemacs-hide-gitignored-files-mode))
              (key-toggle-width   (treemacs--find-keybind #'treemacs-toggle-fixed-width))
+             (key-git-status-ind (treemacs--find-keybind #'treemacs-git-status-indicator-mode))
              (key-add-project    (treemacs--find-keybind #'treemacs-add-project-to-workspace 12))
              (key-remove-project (treemacs--find-keybind #'treemacs-remove-project-from-workspace 12))
              (key-rename-project (treemacs--find-keybind #'treemacs-rename-project 12))
@@ -161,7 +162,7 @@ find the key a command is bound to it will show a blank instead."
 %s root up          ^^^^│ %s open ace vertical   ^^^^│ %s indent guide          ^^^^│
 %s root down        ^^^^│ %s open mru window     ^^^^│ %s top scroll indicator  ^^^^│
                         │ %s open externally     ^^^^│ %s git commit difference ^^^^│
-                        │ %s open close treemacs ^^^^│                              │
+                        │ %s open close treemacs ^^^^│ %s git status indicator  ^^^^│
                         │ %s close parent        ^^^^│                              │
 "
                title
@@ -177,7 +178,7 @@ find the key a command is bound to it will show a blank instead."
                (car key-root-up)        (car key-open-ace-v)  (car key-indent-guide)
                (car key-root-down)      (car key-open-mru)    (car key-header-mode)
                                         (car key-open-ext)    (car key-commit-diff)
-                                        (car key-open-close)
+                                        (car key-open-close)  (car key-git-status-ind)
                                         (car key-close-above))))
           (eval
            `(defhydra treemacs--common-helpful-hydra (:exit nil :hint nil :columns 4)
@@ -214,6 +215,7 @@ find the key a command is bound to it will show a blank instead."
               (,(cdr key-indent-guide)   #'treemacs-indent-guide-mode)
               (,(cdr key-git-mode)       #'treemacs-git-mode)
               (,(cdr key-fwatch-mode)    #'treemacs-filewatch-mode)
+              (,(cdr key-git-status-ind) #'treemacs-git-status-indicator-mode)
               (,(cdr key-add-project)    #'treemacs-add-project-to-workspace)
               (,(cdr key-remove-project) #'treemacs-remove-project-from-workspace)
               (,(cdr key-rename-project) #'treemacs-rename-project)

--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -132,6 +132,7 @@ Will be set by `treemacs--post-command'.")
     (define-key map (kbd "n")        'treemacs-indent-guide-mode)
     (define-key map (kbd "c")        'treemacs-indicate-top-scroll-mode)
     (define-key map (kbd "d")        'treemacs-git-commit-diff-mode)
+    (define-key map (kbd "s")        'treemacs-git-status-indicator-mode)
     map)
   "Keymap for commands that toggle state in `treemacs-mode'.")
 


### PR DESCRIPTION
## Summary

New global minor mode `treemacs-git-status-indicator-mode` that displays single-letter git status indicators (M, A, ?, !, U, R) in the buffer margin next to each file or directory node.

### Features

- **Colored indicators** — each letter uses the same face as the filename (`treemacs-git-modified-face`, `treemacs-git-added-face`, etc.)
- **hl-line integration** — the indicator responds to hl-line highlighting identically to filenames: when a line is selected, the indicator's face is composited with the hl-line face, and restored when the cursor moves away. This also works correctly when git status changes on the currently highlighted line (e.g. saving a modified file while it's selected in treemacs).
- **Left/right margin** — controlled by the new defcustom `treemacs-git-status-indicator-position` (default `left`). The margin is always positioned between the fringe and the text area.
- **Toggle keybinding** — `t s` in the treemacs toggle map
- **Evaporating overlays** — indicator overlays are automatically cleaned up when their line is removed (e.g. file deletion)

### Screenshot

<img width="235" height="211" alt="indicator-screenshot" src="https://github.com/user-attachments/assets/d7402597-e5bf-4c88-a2a9-16cbe91fd52b" />

### Implementation

- Adds a lightweight hook variable `treemacs--after-annotation-applied` in `treemacs-annotations.el`, called at the end of the `treemacs--do-apply-annotation` inline with the button and git-face as arguments. When nil (the default) this is a no-op.
- The new file `treemacs-git-status-indicator.el` uses per-line overlays with a `before-string` margin display spec. The git face is set on the overlay's own `face` property (not as a text property on the before-string), which allows Emacs to apply it to the margin content and allows the mode to swap it for hl-line compositing.
- Follows the same patterns as `treemacs-fringe-indicator.el` (hl-line-highlight advice) and `treemacs-git-commit-diff-mode.el` (mode structure and toggle map).

## Test plan

- [ ] Enable `treemacs-git-mode` and `treemacs-git-status-indicator-mode`
- [ ] Verify indicators appear with correct letters and colors
- [ ] Move cursor through treemacs — indicator color should change with hl-line highlight
- [ ] Edit and save a file in another buffer — indicator should appear/disappear and respect current highlight
- [ ] Delete a file — indicator should disappear along with the node
- [ ] Test `(setq treemacs-git-status-indicator-position 'right)` and re-enable the mode
- [ ] Disable the mode — all indicators, margins, and advice should be cleaned up