### PR TITLE
Add configurable directory face mode for git status

### DIFF
--- a/src/elisp/treemacs-async.el
+++ b/src/elisp/treemacs-async.el
@@ -101,6 +101,25 @@ DEFAULT: Face"
        ("R" 'treemacs-git-renamed-face)
        (_   ,default)))))
 
+(defun treemacs--git-directory-face-mode-arg ()
+  "Compute the Python argument string for directory face mode.
+Returns \"modified\" when `treemacs-git-directory-face-mode' is \\='modified,
+otherwise a comma-separated severity string like \"U,M,?,A,R\"."
+  (if (eq treemacs-git-directory-face-mode 'modified)
+      "modified"
+    (let ((symbol-to-status '((conflict  . "U")
+                              (modified  . "M")
+                              (untracked . "?")
+                              (added     . "A")
+                              (renamed   . "R"))))
+      (if (null treemacs-git-directory-face-severity-list)
+          "modified"
+        (mapconcat (lambda (sym)
+                     (or (cdr (assq sym symbol-to-status))
+                         (error "Unknown severity symbol: %s" sym)))
+                   treemacs-git-directory-face-severity-list
+                   ",")))))
+
 (defvar treemacs--git-mode nil
   "Saves the specific version of git-mode that is active.
 Values are either `simple', `extended', `deferred' or nil.")
@@ -159,6 +178,7 @@ Real implementation will be `fset' based on `treemacs-git-mode' value."
                       ,git-root
                       ,(number-to-string treemacs-max-git-entries)
                       ,treemacs-git-command-pipe
+                      ,(treemacs--git-directory-face-mode-arg)
                       ,@open-dirs))
            (future (apply #'pfuture-new command)))
       future)))
@@ -187,7 +207,12 @@ GIT-FUTURE: Pfuture"
           (when (= 0 (process-exit-status git-future))
             (-let [parsed-output (read git-output)]
               (if (hash-table-p parsed-output)
-                  parsed-output
+                  (progn
+                    (when (functionp treemacs-git-directory-face-mode)
+                      (let ((result (funcall treemacs-git-directory-face-mode parsed-output)))
+                        (when (hash-table-p result)
+                          (setf parsed-output result))))
+                    parsed-output)
                 (let ((inhibit-message t))
                   (treemacs-log-err "treemacs-git-status.py output: %s" git-output))
                 (treemacs-log-err "treemacs-git-status.py did not output a valid hash table. See full output in *Messages*.")

--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -839,6 +839,45 @@ output to a manageable volume for treemacs."
   :type 'string
   :group 'treemacs-git)
 
+(defcustom treemacs-git-directory-face-mode 'modified
+  "Determines how git faces are assigned to parent directories.
+
+In extended and deferred git-mode, when a file has a git status, all of its
+ancestor directories are also assigned a git face.  This variable controls how
+that face is determined.
+
+There are 3 options:
+ - `modified': directories always get `treemacs-git-modified-face' (the default,
+   preserving existing behavior).
+ - `severity': the face is determined by a severity hierarchy.  When all
+   children share the same status the directory inherits that status.  When
+   children have mixed statuses the highest-severity status wins.  The default
+   hierarchy (highest to lowest) is: conflict, modified, untracked, added,
+   renamed.  Customize with `treemacs-git-directory-face-severity-list'.
+ - A function: the function is called with the git-info hash table after the
+   Python script has been parsed.  It receives a hash table mapping absolute
+   file/directory paths to face symbols and should modify it in place or return
+   a new hash table.  The Python script uses `severity' logic as a baseline when
+   a function is specified."
+  :type '(choice (const :tag "Always modified (default)" modified)
+                 (const :tag "Severity-based" severity)
+                 (function :tag "Custom function"))
+  :group 'treemacs-git)
+
+(defcustom treemacs-git-directory-face-severity-list
+  '(conflict modified untracked added renamed)
+  "Severity hierarchy for directory git faces, from highest to lowest.
+
+Only relevant when `treemacs-git-directory-face-mode' is `severity' or a custom
+function.  Each element is a symbol corresponding to a git status.  The first
+element has the highest severity."
+  :type '(repeat (choice (const conflict)
+                         (const modified)
+                         (const untracked)
+                         (const added)
+                         (const renamed)))
+  :group 'treemacs-git)
+
 (defcustom treemacs-is-never-other-window nil
   "When non-nil treemacs will use the `no-other-window' parameter.
 

--- a/src/extra/treemacs-magit.el
+++ b/src/extra/treemacs-magit.el
@@ -101,6 +101,7 @@ current git status and just go through the lines as they are right now."
                         ,magit-root
                         ,(number-to-string treemacs-max-git-entries)
                         ,treemacs-git-command-pipe
+                        ,(treemacs--git-directory-face-mode-arg)
                         ,@visible-dirs)
       :directory magit-root
       :on-success
@@ -112,6 +113,10 @@ current git status and just go through the lines as they are right now."
   "Run the update as a pfuture callback.
 Will update nodes under MAGIT-ROOT with output in PFUTURE-BUFFER."
   (let ((ht (read (pfuture-output-from-buffer pfuture-buffer))))
+    (when (and (hash-table-p ht) (functionp treemacs-git-directory-face-mode))
+      (let ((result (funcall treemacs-git-directory-face-mode ht)))
+        (when (hash-table-p result)
+          (setf ht result))))
     (treemacs-run-in-every-buffer
      (let ((dom-node (or (treemacs-find-in-dom magit-root)
                          (when-let* ((project

--- a/src/scripts/treemacs-git-status.py
+++ b/src/scripts/treemacs-git-status.py
@@ -9,7 +9,9 @@ import sys
 #    the actual working directory is set in emacs
 # 2) `treemacs-max-git-entries`
 # 3) `treemacs-git-command-pipe`
-# 4) a list of expanded directories the script may recurse into to collect
+# 4) directory face mode - either "modified" or a comma-separated severity
+#    hierarchy like "U,M,?,A,R" (see `treemacs-git-directory-face-mode')
+# 5) a list of expanded directories the script may recurse into to collect
 #    an entry for every untracked/ignored file inside
 #    this list is turned into a set since it is possible that it contains duplicates
 #    when called for magit, see also `treemacs-magit--extended-git-mode-update`
@@ -18,8 +20,14 @@ GIT_BIN      = sys.argv[1]
 GIT_ROOT     = str.encode(sys.argv[2])
 LIMIT        = int(sys.argv[3])
 GIT_CMD      = "{} status --porcelain --ignored=matching . ".format(GIT_BIN) + sys.argv[4]
+DIR_MODE     = sys.argv[5] if len(sys.argv) > 5 else "modified"
 STDOUT       = sys.stdout.buffer
-RECURSE_DIRS = set([str.encode(it[(len(GIT_ROOT)):]) + b"/" for it in sys.argv[5:]]) if len(sys.argv) > 5 else []
+RECURSE_DIRS = set([str.encode(it[(len(GIT_ROOT)):]) + b"/" for it in sys.argv[6:]]) if len(sys.argv) > 6 else []
+
+if DIR_MODE == "modified":
+    SEVERITY_ORDER = None
+else:
+    SEVERITY_ORDER = [s.encode() for s in DIR_MODE.split(",")]
 QUOTE        = b'"'
 output       = []
 ht_size      = 0
@@ -40,6 +48,13 @@ def face_for_status(status):
     else:
         return b"font-lock-keyword-face"
 
+def resolve_dir_face(statuses):
+    """Resolve a directory's face from its children's statuses using the severity hierarchy."""
+    for status in SEVERITY_ORDER:
+        if status in statuses:
+            return face_for_status(status)
+    return b"treemacs-git-modified-face"
+
 def find_recursive_entries(path, state):
     global output, ht_size
     for item in listdir(path):
@@ -58,6 +73,7 @@ def main():
     environ["GIT_OPTIONAL_LOCKS"] = "0"
     proc = Popen(GIT_CMD, shell=True, stdout=PIPE, bufsize=100)
     dirs_added = {}
+    dirs_statuses = {} if SEVERITY_ORDER is not None else None
 
     for item in proc.stdout:
         # remove final newline
@@ -101,9 +117,17 @@ def main():
                 full_dirname = join(GIT_ROOT, dirname.lstrip())
                 # directories should not be printed more than once, which would happen if
                 # e.g. both /A/B/C/x and /A/B/C/y have changes
-                if full_dirname not in dirs_added:
-                    output.append(QUOTE + full_dirname.replace(b'"', b'\\"') + QUOTE + b"treemacs-git-modified-face")
-                    ht_size += 1
+                if SEVERITY_ORDER is None:
+                    # modified mode: existing behavior
+                    if full_dirname not in dirs_added:
+                        output.append(QUOTE + full_dirname.replace(b'"', b'\\"') + QUOTE + b"treemacs-git-modified-face")
+                        ht_size += 1
+                        dirs_added[full_dirname] = True
+                else:
+                    # severity mode: collect statuses, defer output
+                    if full_dirname not in dirs_statuses:
+                        dirs_statuses[full_dirname] = set()
+                    dirs_statuses[full_dirname].add(state)
                     dirs_added[full_dirname] = True
         # for untracked and ignored directories we need to find an entry for every single file
         # they contain
@@ -113,6 +137,13 @@ def main():
                 find_recursive_entries(abs_path, state)
         if ht_size >= LIMIT:
             break
+
+    # second pass: emit deferred directory entries for severity mode
+    if dirs_statuses is not None:
+        for full_dirname, statuses in dirs_statuses.items():
+            output.append(QUOTE + full_dirname.replace(b'"', b'\\"') + QUOTE + resolve_dir_face(statuses))
+            ht_size += 1
+
     STDOUT.write(
         b"#s(hash-table size " + \
         bytes(str(ht_size), 'utf-8') + \


### PR DESCRIPTION
## Summary

- Parent directories of changed files were hardcoded to `treemacs-git-modified-face` regardless of children's actual git status (e.g., a directory with only staged/added files showed as "modified")
- Introduces `treemacs-git-directory-face-mode` defcustom with three modes: `modified` (default, preserves existing behavior), `severity` (inherits highest-severity child status), and custom function
- Adds `treemacs-git-directory-face-severity-list` defcustom for configuring the severity hierarchy

### The three modes

**`modified` (default)** — directories always get `treemacs-git-modified-face`. This is the existing behavior; no user configuration changes are needed.

**`severity`** — resolves directory faces using a severity hierarchy. When all children share the same status, the directory inherits that status. When children have mixed statuses, the highest-severity status wins. Default hierarchy (highest to lowest):

| Rank | Status | Rationale |
|------|--------|-----------|
| 1 | Conflict (U) | Blocks merges, must be resolved |
| 2 | Modified (M) | Unstaged changes, dirty working tree |
| 3 | Untracked (?) | Unknown to git, risk of being left out |
| 4 | Added (A) | Already staged — deliberate user action |
| 5 | Renamed (R) | Usually intentional, least concerning |

The hierarchy is customizable via `treemacs-git-directory-face-severity-list`.

**Custom function** — a user-provided function that receives the git-info hash table for post-processing. The Python script resolves directory faces using severity logic as a baseline; the custom function then runs on the Emacs side to adjust the result (it operates on already-resolved severity faces, not raw status codes).

### Files changed

- `src/elisp/treemacs-customization.el` — new defcustom variables
- `src/elisp/treemacs-async.el` — helper function, pass mode to Python, custom function post-processing
- `src/scripts/treemacs-git-status.py` — two-pass directory resolution for severity mode
- `src/extra/treemacs-magit.el` — pass mode arg, custom function post-processing

### Backward compatibility

Default mode is `modified`, producing identical behavior to current code. No existing configuration breaks.

## Test plan

- [ ] `modified` mode: verify directories show `treemacs-git-modified-face` (unchanged behavior)
- [ ] `severity` mode: `git add` new files only → parent directories show `treemacs-git-added-face`; add a modified file → directory switches to `treemacs-git-modified-face`
- [ ] Custom function mode: provide a lambda that remaps faces, verify it takes effect
- [ ] Magit integration: commit via magit, verify refresh uses correct mode