### PR TITLE
[Visuals] Add treemacs-unfocused-hl-line-mode

### DIFF
--- a/Changelog.org
+++ b/Changelog.org
@@ -7,6 +7,7 @@
 *** Added ~treemacs-file-follow-ignore-functions~
 *** Added ~treemacs-buffer-name-prefix~
 *** Added ~treemacs-hide-dot-jj-directory~
+*** Added ~treemacs-unfocused-hl-line-mode~ and ~treemacs-hl-line-unfocused-face~
 ** v3.1
 - Deprecated ~treemacs-window-background-color~ in favour of ~treemacs-window-background-face~ and
   ~treemacs-hl-line-face~

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ ELS += $(SRC_DIR)/treemacs-scope.el
 ELS += $(SRC_DIR)/treemacs-tag-follow-mode.el
 ELS += $(SRC_DIR)/treemacs-tags.el
 ELS += $(SRC_DIR)/treemacs-themes.el
+ELS += $(SRC_DIR)/treemacs-unfocused-hl-line-mode.el
 ELS += $(SRC_DIR)/treemacs-visuals.el
 ELS += $(SRC_DIR)/treemacs-treelib.el
 ELS += $(SRC_DIR)/treemacs-workspaces.el

--- a/README.org
+++ b/README.org
@@ -23,6 +23,7 @@
    - [[#follow-mode][Follow-mode]]
    - [[#tag-follow-mode][Tag-follow-mode]]
    - [[#fringe-indicator-mode][Fringe-indicator-mode]]
+   - [[#unfocused-hl-line-mode][Unfocused-hl-line-mode]]
    - [[#git-mode][Git-mode]]
    - [[#filewatch-mode][Filewatch-mode]]
    - [[#file-management][File Management]]
@@ -260,6 +261,21 @@ cursor.  It can make the selected line more visible if ~hl-line-mode~ doesn't st
 
 The indicator can either be permanently visible, or be only shown when the treemacs window is selected by calling it
 either with the ~always~ or ~only-when-focused~ argument.
+** Unfocused-hl-line-mode
+~treemacs-unfocused-hl-line-mode~ is a global minor mode that swaps the selected-line highlight in treemacs buffers to
+~treemacs-hl-line-unfocused-face~ whenever the treemacs window is not the selected window, and restores
+~treemacs-hl-line-face~ when it regains focus.  Useful in IDE-style layouts, where a dimmer cursor-line in the sidebar
+makes it obvious which side has keyboard focus without losing the indicator of which file the cursor is on.
+
+The default ~treemacs-hl-line-unfocused-face~ inherits from ~treemacs-hl-line-face~, so the appearance is unchanged until
+you customise it.  For example:
+
+#+BEGIN_SRC emacs-lisp
+  (set-face-attribute 'treemacs-hl-line-unfocused-face nil
+                      :background "gray25" :extend t :inherit nil)
+#+END_SRC
+
+Requires ~window-selection-change-functions~, available since Emacs 27.1.
 ** Git-mode
 ~treemacs-git-mode~ is a global minor mode which enables treemacs to check for files' and directories' git status
 information and highlight them accordingly (see also the ~treemacs-git-...~ faces). The mode is available in 3 variants:
@@ -674,6 +690,7 @@ Treemacs defines and uses the following faces:
 | treemacs-git-commit-diff-face          | font-lock-comment-face                           | Face used for ~treemacs-indicate-top-scroll-mode~ annotations.               |
 | treemacs-window-background-face        | default                                          | Face used for the background of the treemacs window.                         |
 | treemacs-hl-line-face                  | hl-line                                          | Face used for hl-line overlay inside the treemacs buffer.                    |
+| treemacs-hl-line-unfocused-face        | treemacs-hl-line-face                            | Face used for hl-line when the treemacs window is not the selected window, while ~treemacs-unfocused-hl-line-mode~ is active. |
 
 ** Evil compatibility
 To make treemacs get along with evil-mode you need to install and load ~treemacs-evil~. It does not define any functions

--- a/src/elisp/treemacs-faces.el
+++ b/src/elisp/treemacs-faces.el
@@ -46,6 +46,14 @@ variant), so it will only be used if git-mode is disabled or set to simple."
   "Face used for the hl-line selection in the treemacs window."
   :group 'treemacs-faces)
 
+(defface treemacs-hl-line-unfocused-face
+  '((t :inherit treemacs-hl-line-face))
+  "Face used for the hl-line selection when the treemacs window is unfocused.
+Only takes effect while `treemacs-unfocused-hl-line-mode' is active.
+Defaults to inheriting from `treemacs-hl-line-face' so the appearance is
+unchanged until the user customises it."
+  :group 'treemacs-faces)
+
 (defface treemacs-file-face
   '((t :inherit default))
   "Face used by treemacs for files."

--- a/src/elisp/treemacs-unfocused-hl-line-mode.el
+++ b/src/elisp/treemacs-unfocused-hl-line-mode.el
@@ -1,0 +1,115 @@
+;;; treemacs-unfocused-hl-line-mode.el --- Dim the treemacs hl-line when unfocused -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 rain-64
+
+;; Author: rain-64 <https://github.com/rain-64>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Minor mode that swaps the selected-line highlight in treemacs buffers
+;; to `treemacs-hl-line-unfocused-face' whenever the treemacs window is
+;; not the selected window, and restores `treemacs-hl-line-face' when
+;; the treemacs window regains focus.
+
+;; NOTE: This module is lazy-loaded.
+
+;;; Code:
+
+(require 'face-remap)
+(require 'hl-line)
+(require 'treemacs-faces)
+
+(eval-when-compile
+  (require 'treemacs-macros))
+
+(defun treemacs--hl-line-apply-unfocused ()
+  "Swap `treemacs-hl-line-face' to the unfocused face in the current buffer.
+Replaces the base definition of `treemacs-hl-line-face' locally so the
+existing `hl-line' remap resolves to `treemacs-hl-line-unfocused-face'.
+Calls `hl-line-highlight' to force the overlay to pick up the new face
+without waiting for point to move."
+  (face-remap-set-base 'treemacs-hl-line-face
+                       'treemacs-hl-line-unfocused-face)
+  (hl-line-highlight))
+
+(defun treemacs--hl-line-apply-focused ()
+  "Restore the default definition of `treemacs-hl-line-face' in this buffer.
+Calls `hl-line-highlight' to force the overlay to pick up the restored
+face without waiting for point to move."
+  (face-remap-reset-base 'treemacs-hl-line-face)
+  (hl-line-highlight))
+
+(defun treemacs--hl-line-update-focus (&rest _)
+  "Reapply the focused or unfocused hl-line face in all treemacs buffers.
+A treemacs buffer is considered focused when it is displayed in the
+globally selected window; all other treemacs buffers get the
+unfocused face."
+  (treemacs-run-in-all-derived-buffers
+   (if (eq (window-buffer (selected-window)) (current-buffer))
+       (treemacs--hl-line-apply-focused)
+     (treemacs--hl-line-apply-unfocused))))
+
+(defun treemacs--setup-unfocused-hl-line-mode ()
+  "Setup for `treemacs-unfocused-hl-line-mode'."
+  (add-hook 'window-selection-change-functions
+            #'treemacs--hl-line-update-focus)
+  (add-hook 'treemacs-mode-hook #'treemacs--hl-line-update-focus)
+  (treemacs--hl-line-update-focus))
+
+(defun treemacs--tear-down-unfocused-hl-line-mode ()
+  "Tear-down for `treemacs-unfocused-hl-line-mode'."
+  (remove-hook 'window-selection-change-functions
+               #'treemacs--hl-line-update-focus)
+  (remove-hook 'treemacs-mode-hook #'treemacs--hl-line-update-focus)
+  (treemacs-run-in-all-derived-buffers
+   (treemacs--hl-line-apply-focused)))
+
+;;;###autoload
+(define-minor-mode treemacs-unfocused-hl-line-mode
+  "Minor mode to dim the treemacs hl-line when treemacs is not focused.
+
+When enabled the selected-line highlight in every treemacs buffer is
+drawn with `treemacs-hl-line-unfocused-face' whenever the treemacs
+window is not the selected window, and with `treemacs-hl-line-face'
+when it is.  Useful in IDE-style layouts, where a visible but dimmer
+cursor line in the sidebar makes it obvious at a glance which side
+has keyboard focus without losing the indicator of which file the
+cursor is on.
+
+Customise `treemacs-hl-line-unfocused-face' to control what the
+unfocused highlight looks like.  Its default inherits from
+`treemacs-hl-line-face' so appearance is unchanged until customised.
+
+Requires `window-selection-change-functions', available since
+Emacs 27.1."
+  :init-value nil
+  :global     t
+  :lighter    nil
+  :group      'treemacs
+  (cond
+   ((not treemacs-unfocused-hl-line-mode)
+    (treemacs--tear-down-unfocused-hl-line-mode))
+   ((not (boundp 'window-selection-change-functions))
+    (setq treemacs-unfocused-hl-line-mode nil)
+    (user-error "%s %s"
+                "treemacs-unfocused-hl-line-mode is only available in Emacs"
+                "versions that support `window-selection-change-functions'"))
+   (t
+    (treemacs--setup-unfocused-hl-line-mode))))
+
+(provide 'treemacs-unfocused-hl-line-mode)
+
+;;; treemacs-unfocused-hl-line-mode.el ends here


### PR DESCRIPTION
## Summary

- New global minor mode `treemacs-unfocused-hl-line-mode` that swaps the selected-line highlight in every treemacs buffer to a new `treemacs-hl-line-unfocused-face` whenever the treemacs window is not the selected window, and restores `treemacs-hl-line-face` when it regains focus.
- New face `treemacs-hl-line-unfocused-face`, defaulting to `:inherit treemacs-hl-line-face` so the appearance is unchanged until the user customises it.
- Wired on `window-selection-change-functions` (Emacs 27.1+); refuses to enable on older versions with a `user-error`, matching the pattern used by `treemacs-peek-mode`.
- A `treemacs-mode-hook` handler is also installed so freshly-created treemacs buffers pick up the correct state immediately.

## Motivation

In IDE-style layouts where treemacs lives in a side window, the `hl-line` highlight is visible at all times whether or not the sidebar has focus. That makes it awkward to tell at a glance which pane is currently selected without losing the indicator of which file the cursor is on in treemacs.

Previously this required a custom `face-remap-set-base` / `window-selection-change-functions` setup in the user's init. This patch brings the behaviour into treemacs itself with a single toggleable mode and a customisable face.

## Implementation notes

- Uses `face-remap-set-base` (not `face-remap-add-relative`) on `treemacs-hl-line-face` to swap the resolved face. Stacking relative remaps over the existing `hl-line` → `treemacs-hl-line-face` remap doesn't work — the earlier spec wins, so the unfocused face would be hidden.
- After every face swap, `hl-line-highlight` is called so the existing overlay picks up the new face immediately rather than waiting for point to move.
- Focus check uses `(eq (window-buffer (selected-window)) (current-buffer))`, which behaves correctly when treemacs is shown in multiple frames.

## Usage

```elisp
(treemacs-unfocused-hl-line-mode 1)

(set-face-attribute 'treemacs-hl-line-unfocused-face nil
                    :background "gray25" :extend t :inherit nil)
```

## Documentation

- Added the face to the Faces table in `README.org`.
- Added an "Unfocused-hl-line-mode" section after "Fringe-indicator-mode" with an index link.
- Added a Changelog entry.

## Test plan

- [x] `make compile` style byte-compile of the new file completes cleanly with `byte-compile-error-on-warn`.
- [x] Loading `treemacs` and toggling the mode on/off in a batch Emacs returns without errors.
- [x] Manual: enabled the mode, confirmed treemacs hl-line uses `treemacs-hl-line-unfocused-face` when another window is selected and `treemacs-hl-line-face` when treemacs is selected, both initially and across focus transitions.
- [x] Manual: customised `treemacs-hl-line-unfocused-face` to a distinct colour (gray25) and verified the change is reflected on the next focus change.
- [x] Manual: disabled the mode and confirmed the highlight reverts in every treemacs buffer.