### PR TITLE
Add arrow key navigation mode

### DIFF
--- a/src/elisp/treemacs-arrow-keys-mode.el
+++ b/src/elisp/treemacs-arrow-keys-mode.el
@@ -1,0 +1,53 @@
+;;; treemacs-arrow-keys-mode.el --- Arrow key navigation for treemacs -*- lexical-binding: t -*-
+
+;; Copyright (C) 2024 Alexander Miller
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Minor mode to bind LEFT and RIGHT arrow keys in treemacs buffers.
+;; LEFT collapses the current node or, when already collapsed, moves to the
+;; parent.  RIGHT expands the current node.
+
+;;; Code:
+
+(require 'treemacs-interface)
+(require 'treemacs-mode)
+
+;;;###autoload
+(define-minor-mode treemacs-arrow-keys-mode
+  "Toggle arrow key navigation in treemacs buffers.
+
+When enabled, the LEFT and RIGHT arrow keys are bound in `treemacs-mode-map'.
+
+LEFT is bound to `treemacs-COLLAPSE-action': it will collapse an expanded node,
+or move to its parent when the node is already collapsed or is a leaf.
+
+RIGHT is bound to `treemacs-RIGHT-action': it will expand a collapsed node.
+The exact behaviour of RIGHT is controlled by `treemacs-RIGHT-actions-config'."
+  :init-value nil
+  :global t
+  :lighter nil
+  :group 'treemacs
+  (if treemacs-arrow-keys-mode
+      (progn
+        (define-key treemacs-mode-map [left]  #'treemacs-COLLAPSE-action)
+        (define-key treemacs-mode-map [right] #'treemacs-RIGHT-action))
+    (define-key treemacs-mode-map [left]  nil)
+    (define-key treemacs-mode-map [right] nil)))
+
+(provide 'treemacs-arrow-keys-mode)
+
+;;; treemacs-arrow-keys-mode.el ends here

--- a/src/elisp/treemacs-customization.el
+++ b/src/elisp/treemacs-customization.el
@@ -315,6 +315,23 @@ of how this config works and how to modify it."
   :type '(alist :key-type symbol :value-type treemacs-collapse-action)
   :group 'treemacs)
 
+(defcustom treemacs-RIGHT-actions-config
+  '((root-node-open   . ignore)
+    (root-node-closed . treemacs-toggle-node)
+    (dir-node-open    . ignore)
+    (dir-node-closed  . treemacs-toggle-node)
+    (file-node-open   . ignore)
+    (file-node-closed . treemacs-toggle-node)
+    (tag-node-open    . ignore)
+    (tag-node-closed  . treemacs-toggle-node)
+    (tag-node         . ignore))
+  "Defines the behaviour of `treemacs-RIGHT-action'.
+
+See the doc string of `treemacs-RET-actions-config' for a detailed description
+of how this config works and how to modify it."
+  :type '(alist :key-type symbol :value-type function)
+  :group 'treemacs)
+
 (defcustom treemacs-dotfiles-regex (rx bol "." (1+ any))
   "Files matching this regular expression count as dotfiles.
 This controls the matching behaviour of `treemacs-toggle-show-dotfiles'."

--- a/src/elisp/treemacs-hydras.el
+++ b/src/elisp/treemacs-hydras.el
@@ -140,6 +140,7 @@ find the key a command is bound to it will show a blank instead."
              (key-indent-guide   (treemacs--find-keybind #'treemacs-indent-guide-mode))
              (key-show-gitignore (treemacs--find-keybind #'treemacs-hide-gitignored-files-mode))
              (key-toggle-width   (treemacs--find-keybind #'treemacs-toggle-fixed-width))
+             (key-arrow-keys     (treemacs--find-keybind #'treemacs-arrow-keys-mode))
              (key-add-project    (treemacs--find-keybind #'treemacs-add-project-to-workspace 12))
              (key-remove-project (treemacs--find-keybind #'treemacs-remove-project-from-workspace 12))
              (key-rename-project (treemacs--find-keybind #'treemacs-rename-project 12))
@@ -161,7 +162,7 @@ find the key a command is bound to it will show a blank instead."
 %s root up          ^^^^│ %s open ace vertical   ^^^^│ %s indent guide          ^^^^│
 %s root down        ^^^^│ %s open mru window     ^^^^│ %s top scroll indicator  ^^^^│
                         │ %s open externally     ^^^^│ %s git commit difference ^^^^│
-                        │ %s open close treemacs ^^^^│                              │
+                        │ %s open close treemacs ^^^^│ %s arrow keys            ^^^^│
                         │ %s close parent        ^^^^│                              │
 "
                title
@@ -177,7 +178,7 @@ find the key a command is bound to it will show a blank instead."
                (car key-root-up)        (car key-open-ace-v)  (car key-indent-guide)
                (car key-root-down)      (car key-open-mru)    (car key-header-mode)
                                         (car key-open-ext)    (car key-commit-diff)
-                                        (car key-open-close)
+                                        (car key-open-close)  (car key-arrow-keys)
                                         (car key-close-above))))
           (eval
            `(defhydra treemacs--common-helpful-hydra (:exit nil :hint nil :columns 4)
@@ -214,6 +215,7 @@ find the key a command is bound to it will show a blank instead."
               (,(cdr key-indent-guide)   #'treemacs-indent-guide-mode)
               (,(cdr key-git-mode)       #'treemacs-git-mode)
               (,(cdr key-fwatch-mode)    #'treemacs-filewatch-mode)
+              (,(cdr key-arrow-keys)     #'treemacs-arrow-keys-mode)
               (,(cdr key-add-project)    #'treemacs-add-project-to-workspace)
               (,(cdr key-remove-project) #'treemacs-remove-project-from-workspace)
               (,(cdr key-rename-project) #'treemacs-rename-project)

--- a/src/elisp/treemacs-interface.el
+++ b/src/elisp/treemacs-interface.el
@@ -391,6 +391,33 @@ ACTION should be one of the `treemacs-visit-node-*' commands."
   (setf treemacs-COLLAPSE-actions-config (assq-delete-all state treemacs-COLLAPSE-actions-config))
   (push (cons state action) treemacs-COLLAPSE-actions-config))
 
+(defun treemacs-RIGHT-action (&optional arg)
+  "Run the appropriate RIGHT action for the current button.
+
+In the default configuration this expands closed nodes and does nothing for
+open or leaf nodes.  A potential prefix ARG is passed on to the executed action,
+if possible.
+
+This function's exact configuration is stored in
+`treemacs-RIGHT-actions-config'."
+  (interactive "P")
+  (-when-let (state (treemacs--prop-at-point :state))
+    (--if-let (cdr (assq state treemacs-RIGHT-actions-config))
+      (progn
+        (funcall it arg)
+        (treemacs--evade-image))
+      (treemacs-pulse-on-failure "No RIGHT action defined for node of type %s."
+        (propertize (format "%s" state) 'face 'font-lock-type-face)))))
+
+(defun treemacs-define-RIGHT-action (state action)
+  "Define the behaviour of `treemacs-RIGHT-action'.
+Determines that a button with a given STATE should lead to the execution of
+ACTION.
+The list of possible states can be found in `treemacs-valid-button-states'.
+ACTION should be one of the `treemacs-visit-node-*' commands."
+  (setf treemacs-RIGHT-actions-config (assq-delete-all state treemacs-RIGHT-actions-config))
+  (push (cons state action) treemacs-RIGHT-actions-config))
+
 (defun treemacs-visit-node-in-external-application ()
   "Open current file according to its mime type in an external application.
 Treemacs knows how to open files on linux, windows and macos."

--- a/src/elisp/treemacs-mode.el
+++ b/src/elisp/treemacs-mode.el
@@ -77,6 +77,7 @@ Will be set by `treemacs--post-command'.")
                    treemacs-previous-project
                    treemacs-goto-parent-node
                    treemacs-TAB-action
+                   treemacs-RIGHT-action
                    treemacs-select-window
                    treemacs-leftclick-action))
       (set (intern (symbol-name cmd) ob) t))
@@ -132,6 +133,7 @@ Will be set by `treemacs--post-command'.")
     (define-key map (kbd "n")        'treemacs-indent-guide-mode)
     (define-key map (kbd "c")        'treemacs-indicate-top-scroll-mode)
     (define-key map (kbd "d")        'treemacs-git-commit-diff-mode)
+    (define-key map (kbd "k")        'treemacs-arrow-keys-mode)
     map)
   "Keymap for commands that toggle state in `treemacs-mode'.")
 

--- a/src/elisp/treemacs.el
+++ b/src/elisp/treemacs.el
@@ -46,6 +46,7 @@
 (require 'treemacs-compatibility)
 (require 'treemacs-workspaces)
 (require 'treemacs-fringe-indicator)
+(require 'treemacs-arrow-keys-mode)
 (require 'treemacs-header-line)
 (require 'treemacs-annotations)
 


### PR DESCRIPTION
## Summary

- Add `treemacs-arrow-keys-mode`, an opt-in global minor mode that binds LEFT and RIGHT arrow keys in treemacs buffers
- LEFT is bound to the existing `treemacs-COLLAPSE-action` (collapse open nodes, move to parent for closed/leaf nodes)
- RIGHT is bound to a new `treemacs-RIGHT-action` that expands closed nodes and does nothing for open/leaf nodes — configurable via `treemacs-RIGHT-actions-config`, following the same pattern as the existing RET/TAB/COLLAPSE action configs
- Toggled with `t k` in treemacs, appears in the helpful hydra

## Motivation

Arrow key navigation is a common expectation in tree views (VS Code, IntelliJ, Finder, etc.). This provides a familiar expand/collapse experience without changing any defaults — users opt in by enabling the minor mode.

## Changes

- **New file:** `treemacs-arrow-keys-mode.el` — minor mode definition
- **`treemacs-customization.el`** — `treemacs-RIGHT-actions-config` defcustom
- **`treemacs-interface.el`** — `treemacs-RIGHT-action` and `treemacs-define-RIGHT-action`
- **`treemacs-mode.el`** — eldoc obarray entry, `t k` toggle binding
- **`treemacs-hydras.el`** — arrow keys entry in the helpful hydra
- **`treemacs.el`** — require the new file