### PR TITLE
[Visit] Pick the window next to treemacs, skipping side and dedicated windows

### DIFF
--- a/Changelog.org
+++ b/Changelog.org
@@ -7,6 +7,11 @@
 *** Added ~treemacs-file-follow-ignore-functions~
 *** Added ~treemacs-buffer-name-prefix~
 *** Added ~treemacs-hide-dot-jj-directory~
+*** Fixed ~treemacs-visit-node-no-split~ (and the split variants) opening the wrong window when
+    treemacs sits next to a side window, a strongly-dedicated window, or simply on the right of
+    multiple windows.  The fallback now uses ~window-in-direction~ to pick the window spatially
+    next to treemacs and, on miss, cycles in the matching direction skipping side and dedicated
+    windows.
 ** v3.1
 - Deprecated ~treemacs-window-background-color~ in favour of ~treemacs-window-background-face~ and
   ~treemacs-hl-line-face~

--- a/src/elisp/treemacs-core-utils.el
+++ b/src/elisp/treemacs-core-utils.el
@@ -434,6 +434,46 @@ extensions and special names like this."
   (inline-quote
    (->> ,window (window-buffer) (buffer-name) (s-starts-with? treemacs-buffer-name-prefix))))
 
+(defun treemacs--window-next-to-treemacs (from)
+  "Find a sensible window next to FROM (the treemacs window).
+
+First tries `window-in-direction' in the direction *away* from treemacs
+(`left' when `treemacs-position' is `right', `right' when it is `left')
+to pick the window spatially adjacent to treemacs.  If that returns a
+window that is not a side window and not dedicated, returns it.
+
+Otherwise cycles through the frame in the same direction skipping side
+and dedicated windows: `previous-window' when walking left,
+`next-window' when walking right.  Falls back to the immediate cyclic
+neighbor if every candidate is unsuitable, so behavior is never worse
+than the prior raw `next-window' fallback.
+
+This implements the docstring contract of `treemacs-visit-node-no-split'
+- \"the window next to treemacs\" - even when treemacs sits to the right
+of multiple windows (where `next-window' wraps to the leftmost rather
+than the adjacent one) and even when a side or strongly-dedicated window
+sits between treemacs and the main editor (where `find-file' would
+otherwise fall back to `display-buffer' and split a different window)."
+  (let* ((direction (if (eq treemacs-position 'right) 'left 'right))
+         (step (if (eq direction 'left) #'previous-window #'next-window))
+         (adjacent (window-in-direction direction from)))
+    (cond
+     ((and adjacent
+           (not (window-parameter adjacent 'window-side))
+           (not (window-dedicated-p adjacent)))
+      adjacent)
+     (t
+      (let* ((first-next (funcall step from nil nil))
+             (candidate first-next))
+        (catch 'found
+          (while t
+            (unless (or (window-parameter candidate 'window-side)
+                        (window-dedicated-p candidate))
+              (throw 'found candidate))
+            (setq candidate (funcall step candidate nil nil))
+            (when (eq candidate from)
+              (throw 'found first-next)))))))))
+
 (define-inline treemacs--next-neighbour-of (btn)
   "Get the next same-level neighbour of BTN, if any."
   (declare (side-effect-free t))

--- a/src/elisp/treemacs-interface.el
+++ b/src/elisp/treemacs-interface.el
@@ -197,7 +197,7 @@ ARG is optional and only available so this function can be used as an action."
       (treemacs-pulse-on-failure)))
 
 (defun treemacs-visit-node-vertical-split (&optional arg)
-  "Open current file or tag by vertically splitting `next-window'.
+  "Open current file or tag by vertically splitting the window next to treemacs.
 Stay in the current window with a single prefix argument ARG, or close the
 treemacs window with a double prefix argument."
   (interactive "P")
@@ -213,7 +213,7 @@ treemacs window with a double prefix argument."
     :no-match-explanation "Node is neither a file, a directory or a tag - nothing to do here.")))
 
 (defun treemacs-visit-node-horizontal-split (&optional arg)
-  "Open current file or tag by horizontally splitting `next-window'.
+  "Open current file or tag by horizontally splitting the window next to treemacs.
 Stay in the current window with a single prefix argument ARG, or close the
 treemacs window with a double prefix argument."
   (interactive "P")
@@ -237,9 +237,9 @@ arg."
 
 (defun treemacs-visit-node-no-split (&optional arg)
   "Open current node without performing any window split or window selection.
-The node will be displayed in the window next to treemacs, the exact selection
-is determined by `next-window'.  If the node is already opened in some other
-window then that window will be selected instead.
+The node will be displayed in the window next to treemacs, skipping side and
+dedicated windows.  If the node is already opened in some other window then
+that window will be selected instead.
 Stay in the current window with a single prefix argument ARG, or close the
 treemacs window with a double prefix argument."
   (interactive "P")

--- a/src/elisp/treemacs-macros.el
+++ b/src/elisp/treemacs-macros.el
@@ -32,6 +32,7 @@
   (require 'gv))
 
 (declare-function treemacs--scope-store "treemacs-scope")
+(declare-function treemacs--window-next-to-treemacs "treemacs-core-utils")
 
 (defmacro treemacs-import-functions-from (file &rest functions)
   "Import FILE's FUNCTIONS.
@@ -223,7 +224,7 @@ WINDOW-ARG determines whether the treemacs windows should remain selected,
                     `((when (one-window-p)
                         (save-selected-window
                           (split-window nil nil (if (eq 'left treemacs-position) 'right 'left))))))
-              (select-window (or ,window (next-window (selected-window) nil nil)))
+              (select-window (or ,window (treemacs--window-next-to-treemacs (selected-window))))
               ,@(if split-function
                     `((funcall ,split-function)
                       (other-window 1)))

--- a/test/treemacs-test.el
+++ b/test/treemacs-test.el
@@ -2088,6 +2088,133 @@ EXPECTED-3 is the expected expansion of the \"file.txt\" button."
     (expect (treemacs--prefix-arg-to-recurse-depth "a") :to-be 999)
     (expect (treemacs--prefix-arg-to-recurse-depth (treemacs-project->create!)) :to-be 999)))
 
+(describe "treemacs--window-next-to-treemacs"
+
+  ;; Each spec builds an ephemeral layout in the current frame and tears it
+  ;; down afterwards, so the helper is exercised against real window objects.
+
+  (describe "spatial-adjacent path"
+
+    (it "picks the adjacent window when treemacs is on the right of multiple normal windows"
+      (let* ((a-buf (get-buffer-create " *t-a*"))
+             (b-buf (get-buffer-create " *t-b*"))
+             (tm-buf (get-buffer-create " *t-tm*"))
+             (a-win (selected-window))
+             b-win tm-win)
+        (unwind-protect
+            (let ((treemacs-position 'right))
+              (set-window-buffer a-win a-buf)
+              (setq b-win (split-window-right))
+              (set-window-buffer b-win b-buf)
+              (setq tm-win (split-window b-win nil 'right))
+              (set-window-buffer tm-win tm-buf)
+              ;; Layout L->R: A | B | treemacs.  next-window from treemacs
+              ;; would wrap to A; the helper should pick the adjacent B.
+              (expect (treemacs--window-next-to-treemacs tm-win) :to-be b-win))
+          (when (window-live-p tm-win) (delete-window tm-win))
+          (when (window-live-p b-win) (delete-window b-win)))))
+
+    (it "picks the adjacent window when treemacs is on the left of multiple normal windows"
+      (let* ((tm-buf (get-buffer-create " *t2-tm*"))
+             (b-buf (get-buffer-create " *t2-b*"))
+             (c-buf (get-buffer-create " *t2-c*"))
+             (tm-win (selected-window))
+             b-win c-win)
+        (unwind-protect
+            (let ((treemacs-position 'left))
+              (set-window-buffer tm-win tm-buf)
+              (setq b-win (split-window-right))
+              (set-window-buffer b-win b-buf)
+              (setq c-win (split-window b-win nil 'right))
+              (set-window-buffer c-win c-buf)
+              ;; Layout L->R: treemacs | B | C.  B is the adjacent window.
+              (expect (treemacs--window-next-to-treemacs tm-win) :to-be b-win))
+          (when (window-live-p c-win) (delete-window c-win))
+          (when (window-live-p b-win) (delete-window b-win)))))
+
+    (it "skips a dedicated adjacent window and falls back to a cycle"
+      (let* ((main-buf (get-buffer-create " *t3-main*"))
+             (left-buf (get-buffer-create " *t3-left*"))
+             (right-buf (get-buffer-create " *t3-right*"))
+             (main-win (selected-window))
+             left-win right-win)
+        (unwind-protect
+            (let ((treemacs-position 'right))
+              (set-window-buffer main-win main-buf)
+              (setq left-win (display-buffer-in-side-window
+                              left-buf '((side . left) (slot . 0))))
+              (setq right-win (display-buffer-in-side-window
+                               right-buf '((side . right) (slot . 0))))
+              (set-window-dedicated-p left-win t)
+              ;; treemacs analogue is right-win; the immediate left in this
+              ;; layout is main, which is reachable via the fallback cycle.
+              (expect (treemacs--window-next-to-treemacs right-win)
+                      :to-be main-win))
+          (when (window-live-p left-win) (delete-window left-win))
+          (when (window-live-p right-win) (delete-window right-win))))))
+
+  (describe "bidirectional cycle path"
+
+    (it "cycles leftward when treemacs is on the right and the adjacent window is dedicated"
+      ;; Layout L->R: A | B(dedicated) | treemacs.  Adjacent (B) is dedicated.
+      ;; Cycling leftward via `previous-window' must skip B and land on A.
+      (let* ((a-buf (get-buffer-create " *c1-a*"))
+             (b-buf (get-buffer-create " *c1-b*"))
+             (tm-buf (get-buffer-create " *c1-tm*"))
+             (a-win (selected-window))
+             b-win tm-win)
+        (unwind-protect
+            (let ((treemacs-position 'right))
+              (set-window-buffer a-win a-buf)
+              (setq b-win (split-window-right))
+              (set-window-buffer b-win b-buf)
+              (setq tm-win (split-window b-win nil 'right))
+              (set-window-buffer tm-win tm-buf)
+              (set-window-dedicated-p b-win t)
+              (expect (treemacs--window-next-to-treemacs tm-win) :to-be a-win))
+          (when (window-live-p tm-win) (delete-window tm-win))
+          (when (window-live-p b-win)
+            (set-window-dedicated-p b-win nil)
+            (delete-window b-win)))))
+
+    (it "cycles rightward when treemacs is on the left and the adjacent window is dedicated"
+      ;; Layout L->R: treemacs | B(dedicated) | C.  Adjacent (B) is dedicated.
+      ;; Cycling rightward via `next-window' must skip B and land on C.
+      (let* ((tm-buf (get-buffer-create " *c2-tm*"))
+             (b-buf (get-buffer-create " *c2-b*"))
+             (c-buf (get-buffer-create " *c2-c*"))
+             (tm-win (selected-window))
+             b-win c-win)
+        (unwind-protect
+            (let ((treemacs-position 'left))
+              (set-window-buffer tm-win tm-buf)
+              (setq b-win (split-window-right))
+              (set-window-buffer b-win b-buf)
+              (setq c-win (split-window b-win nil 'right))
+              (set-window-buffer c-win c-buf)
+              (set-window-dedicated-p b-win t)
+              (expect (treemacs--window-next-to-treemacs tm-win) :to-be c-win))
+          (when (window-live-p c-win) (delete-window c-win))
+          (when (window-live-p b-win)
+            (set-window-dedicated-p b-win nil)
+            (delete-window b-win))))))
+
+  (describe "two-window fallback"
+
+    (it "returns the only other window when treemacs is one of two non-dedicated windows"
+      (let* ((main-buf (get-buffer-create " *tw-main*"))
+             (other-buf (get-buffer-create " *tw-other*"))
+             (main-win (selected-window))
+             other-win)
+        (unwind-protect
+            (let ((treemacs-position 'left))
+              (set-window-buffer main-win main-buf)
+              (setq other-win (split-window-right))
+              (set-window-buffer other-win other-buf)
+              (expect (treemacs--window-next-to-treemacs main-win)
+                      :to-be other-win))
+          (when (window-live-p other-win) (delete-window other-win)))))))
+
 (provide 'test-treemacs)
 
 ;;; treemacs-test.el ends here


### PR DESCRIPTION
**Supersedes [#1192](https://github.com/Alexander-Miller/treemacs/pull/1192)** — same dedicated/side-window fix, plus the directional fix #1192 missed, plus a small docstring cleanup, in a single coherent change. Will close #1192 once this is up.

## The bug

The docstring of `treemacs-visit-node-no-split` promises that the visited file appears ["in the window next to treemacs"][docstring]. The implementation used `(next-window (selected-window) nil nil)` as the fallback, which fails the promise in two distinct ways.

### Bug 1: side and dedicated windows get selected

`next-window` does not filter side or dedicated windows. In a layout like `[sidebuf | main | treemacs]` where `sidebuf` is a strongly-dedicated side window on the left, `next-window` from treemacs (on the right) wraps to `sidebuf`. `find-file` can't change the buffer of a strongly-dedicated window, so Emacs falls back to `display-buffer`, which splits a different window — producing one more window than the user expects.

Reproduction:
```elisp
emacs --batch --eval "
(progn
  (let* ((main-buf (get-buffer-create \"*main*\"))
         (left-buf (get-buffer-create \"*left*\"))
         (right-buf (get-buffer-create \"*right*\")))
    (set-window-buffer (selected-window) main-buf)
    (let ((left-win (display-buffer-in-side-window left-buf '((side . left) (slot . 0))))
          (right-win (display-buffer-in-side-window right-buf '((side . right) (slot . 0)))))
      (set-window-dedicated-p left-win t)
      (select-window left-win)
      (find-file \"/tmp/foo.txt\")
      (princ (format \"windows: %s\n\" (mapcar (lambda (w) (buffer-name (window-buffer w))) (window-list))))))"
```
Today: 4 windows. After this PR: the file opens in the main window, no extra split.

### Bug 2: cycle wraps to the leftmost window instead of walking to the adjacent one

`next-window` cycles in the frame's window-list order, typically left-to-right. When treemacs sits on the right of multiple normal windows, `next-window` wraps around to the leftmost window rather than walking backwards to treemacs's immediate left neighbor.

```elisp
(progn
  (require 'treemacs-core-utils)
  (let* ((a (get-buffer-create "*A*"))
         (b (get-buffer-create "*B*"))
         (tm (get-buffer-create "*tm*")))
    (set-window-buffer (selected-window) a)
    (let* ((b-win (split-window-right))
           (t-win (split-window b-win nil 'right)))
      (set-window-buffer b-win b)
      (set-window-buffer t-win tm)
      (message "next-window from treemacs:                %s"
               (buffer-name (window-buffer (next-window t-win nil nil))))
      (message "window-in-direction 'left from treemacs: %s"
               (buffer-name (window-buffer (window-in-direction 'left t-win)))))))
```
Output:
```
next-window from treemacs:                *A*   ← what the macro picks
window-in-direction 'left from treemacs:  *B*   ← what the user expects
```

Both bugs also affect `treemacs-visit-node-vertical-split` and `treemacs-visit-node-horizontal-split`: a side window cannot be split, and splitting the leftmost window when treemacs is on the right is more disorienting than splitting the adjacent one.

## The fix

Add `treemacs--window-next-to-treemacs`, which:

1. **Spatial pick.** Asks Emacs directly via `window-in-direction` for the window spatially adjacent to treemacs. Direction is derived from `treemacs-position` (`'left` when treemacs is on the right, `'right` when treemacs is on the left). If `window-in-direction` returns a non-side, non-dedicated window, return it.

2. **Directional cycle.** Otherwise, cycle through the frame in the same direction skipping side and dedicated windows: `previous-window` when walking left, `next-window` when walking right. Falls back to the immediate cyclic neighbor if every candidate is unsuitable, so behavior is never worse than the prior raw `next-window` fallback.

```elisp
(defun treemacs--window-next-to-treemacs (from)
  "Find a sensible window next to FROM (the treemacs window).

First tries `window-in-direction' in the direction *away* from treemacs
(`left' when `treemacs-position' is `right', `right' when it is `left')
to pick the window spatially adjacent to treemacs.  If that returns a
window that is not a side window and not dedicated, returns it.

Otherwise cycles through the frame in the same direction skipping side
and dedicated windows: `previous-window' when walking left,
`next-window' when walking right.  Falls back to the immediate cyclic
neighbor if every candidate is unsuitable, so behavior is never worse
than the prior raw `next-window' fallback."
  (let* ((direction (if (eq treemacs-position 'right) 'left 'right))
         (step (if (eq direction 'left) #'previous-window #'next-window))
         (adjacent (window-in-direction direction from)))
    (cond
     ((and adjacent
           (not (window-parameter adjacent 'window-side))
           (not (window-dedicated-p adjacent)))
      adjacent)
     (t
      (let* ((first-next (funcall step from nil nil))
             (candidate first-next))
        (catch 'found
          (while t
            (unless (or (window-parameter candidate 'window-side)
                        (window-dedicated-p candidate))
              (throw 'found candidate))
            (setq candidate (funcall step candidate nil nil))
            (when (eq candidate from)
              (throw 'found first-next)))))))))
```

The macro change is a one-line swap:

```diff
-(select-window (or ,window (next-window (selected-window) nil nil)))
+(select-window (or ,window (treemacs--window-next-to-treemacs (selected-window))))
```

The explicit `:window` argument used by callers (`get-mru-window`, `ace-select-window`, an existing window already showing the file) still short-circuits via `or` and is unaffected.

## Edge cases handled

- **`[A | B | treemacs]`, treemacs right, all normal**: spatial pick returns `B` (adjacent). Was `A`.
- **`[sidebuf(dedicated) | main | treemacs]`, treemacs right**: spatial pick returns `main`. Was `sidebuf`, which then triggered the splitting fallback.
- **`[A | B(dedicated) | treemacs]`, treemacs right**: spatial pick rejects `B`, directional cycle walks leftward (`previous-window`) skipping `B` and lands on `A`. Was `A` already (via wrap), but for the wrong reason — now it's the right answer for the right reason.
- **`[treemacs | B | C]`, treemacs left**: spatial pick returns `B` (adjacent). Same as before; behavior unchanged.
- **`[treemacs | B(dedicated) | C]`, treemacs left**: spatial pick rejects `B`, directional cycle walks rightward (`next-window`) skipping `B` and lands on `C`. Was `B` (then `find-file` fallback split). Now lands on `C` cleanly.
- **Two windows total, treemacs + one normal**: spatial pick returns that one window. Unchanged.
- **Treemacs is the only window**: macro's existing `ensure-window-split` branch handles this; helper isn't reached for the split variants. For `no-split`, the degenerate case is the same as today — `window-in-direction` returns nil and the cycle returns treemacs itself.
- **Pathological: every other window is side or dedicated**: cycle exhausts and falls back to the immediate cyclic neighbor, matching today's behavior. Never worse than the raw `next-window`.
- **Explicit `:window` arg**: short-circuited by `or`, helper not reached.

## Functions that benefit

Every caller of `treemacs--execute-button-action` that does not pass an explicit `:window`:

- `treemacs-visit-node-no-split`
- `treemacs-visit-node-vertical-split`
- `treemacs-visit-node-horizontal-split`

Callers that already pass `:window` (MRU, ace-window, reuse-existing-window) are unaffected.

## Docstring updates

The three affected functions had docstrings that referenced `next-window` as the implementation. After this fix those references are stale, so the docstrings are updated to drop the implementation note:

- `treemacs-visit-node-no-split`: "the exact selection is determined by `next-window'" → "skipping side and dedicated windows"
- `treemacs-visit-node-vertical-split`: "vertically splitting `next-window'" → "vertically splitting the window next to treemacs"
- `treemacs-visit-node-horizontal-split`: "horizontally splitting `next-window'" → "horizontally splitting the window next to treemacs"

## Tests

Six buttercup specs added under `treemacs--window-next-to-treemacs` in `test/treemacs-test.el`, in three groups:

- **spatial-adjacent path**: treemacs on the right of multiple normal windows; treemacs on the left of multiple normal windows; dedicated adjacent window forces fallback.
- **bidirectional cycle path**: dedicated adjacent window with cycle going leftward (treemacs on right); same with cycle going rightward (treemacs on left).
- **two-window fallback**: treemacs and one other window.

Full suite (`make test`) is green at 260 / 260. Byte-compile of the changed files is clean.

[docstring]: src/elisp/treemacs-interface.el